### PR TITLE
Viser veilederhilsen og viser hva som må melder fra om.

### DIFF
--- a/app/komponenter/veilederhilsen/veilderhilsen.tsx
+++ b/app/komponenter/veilederhilsen/veilderhilsen.tsx
@@ -1,0 +1,20 @@
+import { GuidePanel, Heading } from '@navikt/ds-react';
+
+import css from './veilederhilsen.module.css';
+
+export default function VeilederHilsen() {
+  return (
+    <GuidePanel poster className={`${css.poster}`}>
+      <Heading level="2" size="xlarge" className={`${css.tittelMargin}`}>
+        Hei [fornavn]
+      </Heading>
+      Du må melde fra til oss hvis:
+      <ul className={`${css.liste}`}>
+        <li>Familiesituasjonen din endrer seg.</li>
+        <li>Dere planlegger opphold i utlandet.</li>
+        <li>Det er endring i arbeidsforhold i utlandet.</li>
+        <li>Du ikke lenger har rett til utvidet barnetrygd.</li>
+      </ul>
+    </GuidePanel>
+  );
+}

--- a/app/komponenter/veilederhilsen/veilederhilsen.module.css
+++ b/app/komponenter/veilederhilsen/veilederhilsen.module.css
@@ -1,0 +1,14 @@
+.poster {
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+}
+
+.tittelMargin {
+  margin-top: 1rem;
+  margin-bottom: 0.6rem;
+}
+
+.liste {
+  margin-top: 0px;
+}

--- a/app/routes/_index.module.css
+++ b/app/routes/_index.module.css
@@ -4,8 +4,18 @@
 
 .fyllSide {
   height: 30rem;
+  padding: 0.5rem;
   display: grid;
   align-items: center;
+}
+
+.innholdkonteiner {
+  max-width: 37.5rem;
+  margin: 0 auto;
+
+  @media (min-width: 768px) {
+    width: 37.5rem;
+  }
 }
 
 .regnbue {

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -2,6 +2,7 @@ import type { V2_MetaFunction } from '@remix-run/node';
 import { Heading } from '@navikt/ds-react';
 import css from './_index.module.css';
 import React from 'react';
+import VeilederHilsen from '../komponenter/veilederhilsen/veilderhilsen';
 
 export const meta: V2_MetaFunction = () => {
   return [
@@ -17,10 +18,12 @@ export const meta: V2_MetaFunction = () => {
 export default function Index() {
   return (
     <div className={`${css.sentrerTekst} ${css.fyllSide}`}>
-      <div>
+      <div className={`${css.innholdkonteiner}`}>
         <Heading level="1" size="xlarge">
           Endringsmelding
         </Heading>
+
+        <VeilederHilsen />
       </div>
     </div>
   );


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

[Lenke til trello kort](https://trello.com/c/5OHtbGqy/21-legge-til-veilederhilsen-med-overskrift-uten-fornavn)

En veileder hilsen for brukeren slik at brukeren ser hva som skal meldes om.
Se skisser på trello kortet. 

### Hvordan er det løst? 🧠

For orden skyld, så lagde eg og Sedric lagde en mappe for komponenter under `app`.
Total pathen for `VeilederHilsen` komponentet ligger under: `app/komponenter/veilederhilsen/veilderhilsen.tsx`.
Styling ligger også i samme mappe til veilederhilsen komponentet.


- Vi brukte Nav sitt innebygde `GuidePanel` i poster format og la til en header med level 2 og size xlarge.
- Vi la også inn en liste med alle tilfeller man må melde fra om. (Den måtte vi fjerne topp marginen fra).
- La til `0.5rem` padding på `.fyllSide` for å gi et lite mellomrom på begge sider. 

I skissen så skal komponentet bruke en bredde på `600px` som er det samme som `37.5rem`.  Dette er bredden på komponentet dersom bredde på enheten er mer enn `768px`. Brukte nav dokumentasjon på brekkpunkter. Dette gjer at resultetet er responsive: [her.](https://aksel.nav.no/grunnleggende/styling/brekkpunkter)

#### Mobil: 
<img width="552" alt="Screenshot 2023-06-15 at 13 34 27" src="https://github.com/bekk/nav-familie-endringsmelding/assets/66110094/cb243b4e-3705-40f8-b176-625a2c3f231e">

### Desktop/vanlig (over `768px` i bredde): 

<img width="1667" alt="Screenshot 2023-06-15 at 13 35 40" src="https://github.com/bekk/nav-familie-endringsmelding/assets/66110094/7d654be8-03e9-450d-b3a9-2e1051139ced">
