### PR TITLE
Punktliste fra sanity

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,4 +8,5 @@ module.exports = {
   rules: {
     '@typescript-eslint/consistent-type-imports': 'off',
   },
+  ignorePatterns: ['!.*', 'dist', 'node_modules'],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,8 +5,11 @@ module.exports = {
     '@remix-run/eslint-config/node',
     'prettier',
   ],
+  plugins: ['unused-imports'],
   rules: {
     '@typescript-eslint/consistent-type-imports': 'off',
+    'no-unused-vars': 'off',
+    'unused-imports/no-unused-imports': 'error',
   },
   ignorePatterns: ['!.*', 'dist', 'node_modules'],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,4 +5,7 @@ module.exports = {
     '@remix-run/eslint-config/node',
     'prettier',
   ],
+  rules: {
+    '@typescript-eslint/consistent-type-imports': 'off',
+  },
 };

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,6 +22,9 @@ jobs:
       - name: 🔬 Lint
         run: npm run lint
 
+      - name: 🔬 Lint staged
+        run: npm run lint-staged
+
   typecheck:
     name: ʦ TypeScript
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,9 +22,6 @@ jobs:
       - name: 🔬 Lint
         run: npm run lint
 
-      - name: 🔬 Lint staged
-        run: npm run lint-staged
-
   typecheck:
     name: ʦ TypeScript
     runs-on: ubuntu-latest

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,7 +1,7 @@
 {
-  "*.(ts|tsx|js|jsx)": [
-    "eslint --cache --cache-location ./node_modules/.cache/eslint",
+  "*.(ts|tsx|js|jsx|css)": [
+    "eslint --fix --max-warnings=0 --cache --cache-location ./node_modules/.cache/eslint",
     "prettier --write"
   ],
-  "*.(json|md|css)": ["prettier --write"]
+  "*.(json|md)": ["prettier --write"]
 }

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,7 +1,7 @@
 {
-  "*.(ts|tsx|js|jsx|css)": [
+  "*.(ts|tsx|js|jsx)": [
     "eslint --fix --max-warnings=0 --cache --cache-location ./node_modules/.cache/eslint",
     "prettier --write"
   ],
-  "*.(json|md)": ["prettier --write"]
+  "*.(json|md|css)": ["prettier --write"]
 }

--- a/app/komponenter/tekstBlokk/tekstBlokk.tsx
+++ b/app/komponenter/tekstBlokk/tekstBlokk.tsx
@@ -19,7 +19,17 @@ const TekstBlokk: React.FC<TekstBlokkProps> = ({
       value={tekstblokk[valgBlock]}
       components={{
         block: {
+          normal: ({ children }) => (
+            <TypografiWrapper typografi={typografi}>
+              {children}
+            </TypografiWrapper>
+          ),
           h1: ({ children }) => (
+            <TypografiWrapper typografi={typografi}>
+              {children}
+            </TypografiWrapper>
+          ),
+          li: ({ children }) => (
             <TypografiWrapper typografi={typografi}>
               {children}
             </TypografiWrapper>

--- a/app/komponenter/tekstBlokk/tekstBlokk.tsx
+++ b/app/komponenter/tekstBlokk/tekstBlokk.tsx
@@ -1,23 +1,23 @@
-import { TypografiTyper } from '~/typer/typografi';
+import type { TypografiTyper } from '~/typer/typografi';
 import React from 'react';
 import { PortableText } from '@portabletext/react';
 import { TypografiWrapper } from '~/utils/typografiWrapper';
-import css from './veilederhilsen.module.css';
+import { LocaleType } from '~/typer/sanity/sanity';
 
-interface TekstBlokkProps {
+interface Props {
   tekstblokk: any | undefined;
-  valgBlock: string;
+  valgSpraak: LocaleType;
   typografi?: TypografiTyper;
 }
 
-const TekstBlokk: React.FC<TekstBlokkProps> = ({
+const TekstBlokk: React.FC<Props> = ({
   tekstblokk,
   typografi,
-  valgBlock,
-}: TekstBlokkProps) => {
+  valgSpraak,
+}: Props) => {
   return tekstblokk ? (
     <PortableText
-      value={tekstblokk[valgBlock]}
+      value={tekstblokk[valgSpraak]}
       components={{
         block: {
           normal: ({ children }) => (

--- a/app/komponenter/tekstBlokk/tekstBlokk.tsx
+++ b/app/komponenter/tekstBlokk/tekstBlokk.tsx
@@ -1,0 +1,33 @@
+import { TypografiTyper } from '~/typer/typografi';
+import React from 'react';
+import { PortableText } from '@portabletext/react';
+import { TypografiWrapper } from '~/utils/typografiWrapper';
+
+interface TekstBlokkProps {
+  tekstblokk: any | undefined;
+  valgBlock: string;
+  typografi?: TypografiTyper;
+}
+
+const TekstBlokk: React.FC<TekstBlokkProps> = ({
+  tekstblokk,
+  typografi,
+  valgBlock,
+}: TekstBlokkProps) => {
+  return tekstblokk ? (
+    <PortableText
+      value={tekstblokk[valgBlock]}
+      components={{
+        block: {
+          h1: ({ children }) => (
+            <TypografiWrapper typografi={typografi}>
+              {children}
+            </TypografiWrapper>
+          ),
+        },
+      }}
+    />
+  ) : null;
+};
+
+export default TekstBlokk;

--- a/app/komponenter/tekstBlokk/tekstBlokk.tsx
+++ b/app/komponenter/tekstBlokk/tekstBlokk.tsx
@@ -2,22 +2,19 @@ import type { TypografiTyper } from '~/typer/typografi';
 import React from 'react';
 import { PortableText } from '@portabletext/react';
 import { TypografiWrapper } from '~/utils/typografiWrapper';
-import { LocaleType } from '~/typer/sanity/sanity';
+import { LocaleType, SanityDokument } from '~/typer/sanity/sanity';
 
 interface Props {
-  tekstblokk: any | undefined;
-  valgSpraak: LocaleType;
+  tekstblokk: SanityDokument | undefined;
   typografi?: TypografiTyper;
 }
 
-const TekstBlokk: React.FC<Props> = ({
-  tekstblokk,
-  typografi,
-  valgSpraak,
-}: Props) => {
+const TekstBlokk: React.FC<Props> = ({ tekstblokk, typografi }: Props) => {
+  const spraak: LocaleType = LocaleType.nb;
+
   return tekstblokk ? (
     <PortableText
-      value={tekstblokk[valgSpraak]}
+      value={tekstblokk[spraak]}
       components={{
         block: {
           normal: ({ children }) => (
@@ -26,11 +23,6 @@ const TekstBlokk: React.FC<Props> = ({
             </TypografiWrapper>
           ),
           h1: ({ children }) => (
-            <TypografiWrapper typografi={typografi}>
-              {children}
-            </TypografiWrapper>
-          ),
-          li: ({ children }) => (
             <TypografiWrapper typografi={typografi}>
               {children}
             </TypografiWrapper>

--- a/app/komponenter/tekstBlokk/tekstBlokk.tsx
+++ b/app/komponenter/tekstBlokk/tekstBlokk.tsx
@@ -2,6 +2,7 @@ import { TypografiTyper } from '~/typer/typografi';
 import React from 'react';
 import { PortableText } from '@portabletext/react';
 import { TypografiWrapper } from '~/utils/typografiWrapper';
+import css from './veilederhilsen.module.css';
 
 interface TekstBlokkProps {
   tekstblokk: any | undefined;
@@ -20,7 +21,7 @@ const TekstBlokk: React.FC<TekstBlokkProps> = ({
       components={{
         block: {
           normal: ({ children }) => (
-            <TypografiWrapper typografi={typografi}>
+            <TypografiWrapper typografi={typografi} style={{ margin: '0' }}>
               {children}
             </TypografiWrapper>
           ),

--- a/app/komponenter/veilederhilsen/veilederhilsen.module.css
+++ b/app/komponenter/veilederhilsen/veilederhilsen.module.css
@@ -2,6 +2,10 @@
   text-align: left;
 }
 
+.poster ul {
+  margin: 0;
+}
+
 .tittelMargin {
   margin-top: 1rem;
   margin-bottom: 0.6rem;

--- a/app/komponenter/veilederhilsen/veilederhilsen.tsx
+++ b/app/komponenter/veilederhilsen/veilederhilsen.tsx
@@ -1,8 +1,17 @@
 import { GuidePanel, Heading } from '@navikt/ds-react';
 
 import css from './veilederhilsen.module.css';
+import { SanityDokument } from '~/typer/sanity/sanity';
+import TekstBlokk from '../tekstBlokk/tekstBlokk';
+import { TypografiTyper } from '~/typer/typografi';
 
-export default function VeilederHilsen() {
+interface VeilederHilsenProp {
+  dokument: SanityDokument | undefined;
+}
+
+const VeilederHilsen: React.FC<VeilederHilsenProp> = ({
+  dokument,
+}: VeilederHilsenProp) => {
   return (
     <GuidePanel poster className={`${css.poster}`}>
       <Heading level="2" size="xlarge" className={`${css.tittelMargin}`}>
@@ -10,11 +19,14 @@ export default function VeilederHilsen() {
       </Heading>
       Du må melde fra til oss hvis:
       <ul className={`${css.liste}`}>
-        <li>Familiesituasjonen din endrer seg.</li>
-        <li>Dere planlegger opphold i utlandet.</li>
-        <li>Det er endring i arbeidsforhold i utlandet.</li>
-        <li>Du ikke lenger har rett til utvidet barnetrygd.</li>
+        <TekstBlokk
+          tekstblokk={dokument}
+          valgBlock="en"
+          typografi={TypografiTyper.Liste}
+        />
       </ul>
     </GuidePanel>
   );
-}
+};
+
+export default VeilederHilsen;

--- a/app/komponenter/veilederhilsen/veilederhilsen.tsx
+++ b/app/komponenter/veilederhilsen/veilederhilsen.tsx
@@ -1,38 +1,21 @@
 import { GuidePanel, Heading } from '@navikt/ds-react';
-
 import css from './veilederhilsen.module.css';
 import { SanityDokument } from '~/typer/sanity/sanity';
 import TekstBlokk from '../tekstBlokk/tekstBlokk';
-import { TypografiTyper } from '~/typer/typografi';
 
 interface VeilederHilsenProp {
-  punktlisteDokument: SanityDokument | undefined;
-  tittelPunktlisteDokument: SanityDokument | undefined;
-  spraak: string;
+  innhold: SanityDokument | undefined;
 }
 
 const VeilederHilsen: React.FC<VeilederHilsenProp> = ({
-  punktlisteDokument,
-  tittelPunktlisteDokument,
-  spraak,
+  innhold,
 }: VeilederHilsenProp) => {
   return (
     <GuidePanel poster className={`${css.poster}`}>
       <Heading level="2" size="xlarge" className={`${css.tittelMargin}`}>
         Hei [fornavn]
       </Heading>
-      <TekstBlokk
-        tekstblokk={tittelPunktlisteDokument}
-        valgBlock={spraak}
-        typografi={TypografiTyper.Normal}
-      />
-      <ul className={`${css.liste}`}>
-        <TekstBlokk
-          tekstblokk={punktlisteDokument}
-          valgBlock={spraak}
-          typografi={TypografiTyper.Liste}
-        />
-      </ul>
+      <TekstBlokk tekstblokk={innhold} />
     </GuidePanel>
   );
 };

--- a/app/komponenter/veilederhilsen/veilederhilsen.tsx
+++ b/app/komponenter/veilederhilsen/veilederhilsen.tsx
@@ -6,22 +6,30 @@ import TekstBlokk from '../tekstBlokk/tekstBlokk';
 import { TypografiTyper } from '~/typer/typografi';
 
 interface VeilederHilsenProp {
-  dokument: SanityDokument | undefined;
+  punktlisteDokument: SanityDokument | undefined;
+  tittelPunktlisteDokument: SanityDokument | undefined;
+  spraak: string;
 }
 
 const VeilederHilsen: React.FC<VeilederHilsenProp> = ({
-  dokument,
+  punktlisteDokument,
+  tittelPunktlisteDokument,
+  spraak,
 }: VeilederHilsenProp) => {
   return (
     <GuidePanel poster className={`${css.poster}`}>
       <Heading level="2" size="xlarge" className={`${css.tittelMargin}`}>
         Hei [fornavn]
       </Heading>
-      Du må melde fra til oss hvis:
+      <TekstBlokk
+        tekstblokk={tittelPunktlisteDokument}
+        valgBlock={spraak}
+        typografi={TypografiTyper.Normal}
+      />
       <ul className={`${css.liste}`}>
         <TekstBlokk
-          tekstblokk={dokument}
-          valgBlock="en"
+          tekstblokk={punktlisteDokument}
+          valgBlock={spraak}
           typografi={TypografiTyper.Liste}
         />
       </ul>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,6 +1,6 @@
 import { cssBundleHref } from '@remix-run/css-bundle';
 import designsystemStyles from '@navikt/ds-css/dist/index.css';
-import type { LinksFunction } from '@remix-run/node';
+import type { LinksFunction, LoaderFunction } from '@remix-run/node';
 import {
   Links,
   LiveReload,
@@ -8,14 +8,22 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
+  useLoaderData,
 } from '@remix-run/react';
+import { hentDataFraSanity } from './utils/sanityLoader';
 
 export const links: LinksFunction = () => [
   { rel: 'stylesheet', href: designsystemStyles },
   ...(cssBundleHref ? [{ rel: 'stylesheet', href: cssBundleHref }] : []),
 ];
 
+export const loader: LoaderFunction = async () => {
+  return await hentDataFraSanity();
+};
+
 export default function App() {
+  const data = useLoaderData<typeof loader>();
+
   return (
     <html lang="en">
       <head>
@@ -25,7 +33,7 @@ export default function App() {
         <Links />
       </head>
       <body>
-        <Outlet />
+        <Outlet context={data} />
         <ScrollRestoration />
         <Scripts />
         <LiveReload />

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -20,7 +20,6 @@ export const meta: V2_MetaFunction = () => {
 
 export default function Index() {
   const tekster = useTekster(ESanitySteg.FORSIDE);
-  console.log(tekster);
 
   return (
     <div className={`${css.sentrerTekst} ${css.fyllSide}`}>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,6 +1,6 @@
 import type { V2_MetaFunction } from '@remix-run/node';
 import css from './_index.module.css';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Spinner from '~/komponenter/Spinner';
 import VeilederHilsen from '../komponenter/veilederhilsen/veilederhilsen';
 import { ESanitySteg } from '~/typer/sanity/sanity';
@@ -21,18 +21,11 @@ export const meta: V2_MetaFunction = () => {
 
 export default function Index() {
   const tekster = useTekster(ESanitySteg.FORSIDE);
-  const [laster, settLaster] = useState(true);
-
-  useEffect(() => {
-    if (tekster) {
-      settLaster(false);
-    }
-  }, [tekster]);
 
   return (
     <div className={`${css.sentrerTekst} ${css.fyllSide}`}>
       <div className={`${css.innholdKonteiner}`}>
-        {laster ? (
+        {!tekster ? (
           <Spinner />
         ) : (
           <>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -31,7 +31,7 @@ export default function Index() {
 
   return (
     <div className={`${css.sentrerTekst} ${css.fyllSide}`}>
-      <div className={`${css.innholdkonteiner}`}>
+      <div className={`${css.innholdKonteiner}`}>
         {laster ? (
           <Spinner />
         ) : (

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -41,19 +41,18 @@ export default function Index() {
   const dokumenter: Map<ESanityApiKey, SanityDokument> = new Map();
   forsideTekst.map(dokument => dokumenter.set(dokument.api_navn, dokument));
 
-  console.log(dokumenter.get(ESanityApiKey.TITTEL));
+  const punktlisteDokument = dokumenter.get(ESanityApiKey.PUNKTLISTE);
 
   return (
     <div className={`${css.sentrerTekst} ${css.fyllSide}`}>
       <div className={`${css.innholdkonteiner}`}>
-        <Heading level="1" size="xlarge">
-          <TekstBlokk
-            tekstblokk={dokumenter.get(ESanityApiKey.TITTEL)}
-            valgBlock="nn"
-            typografi={TypografiTyper.StegHeadingH1}
-          />
-        </Heading>
-        <VeilederHilsen />
+        <TekstBlokk
+          tekstblokk={dokumenter.get(ESanityApiKey.TITTEL)}
+          valgBlock="nb"
+          typografi={TypografiTyper.StegHeadingH1}
+        />
+
+        <VeilederHilsen dokument={punktlisteDokument} />
       </div>
     </div>
   );

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,6 +1,6 @@
 import type { V2_MetaFunction } from '@remix-run/node';
 import css from './_index.module.css';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Spinner from '~/komponenter/Spinner';
 import VeilederHilsen from '../komponenter/veilederhilsen/veilederhilsen';
 import { ESanitySteg } from '~/typer/sanity/sanity';
@@ -22,7 +22,7 @@ export const meta: V2_MetaFunction = () => {
 export default function Index() {
   const tekster = useTekster(ESanitySteg.FORSIDE);
   const [laster, settLaster] = useState(true);
-  
+
   useEffect(() => {
     if (tekster) {
       settLaster(false);
@@ -32,17 +32,17 @@ export default function Index() {
   return (
     <div className={`${css.sentrerTekst} ${css.fyllSide}`}>
       <div className={`${css.innholdkonteiner}`}>
-         {laster ? (
+        {laster ? (
           <Spinner />
-          ) : (
-            <>
-              <TekstBlokk
-                tekstblokk={tekster.tittel}
-                typografi={TypografiTyper.StegHeadingH1}
-              />
-              <VeilederHilsen innhold={tekster.veilederhilsenInnhold} />
-            </>
-          )}
+        ) : (
+          <>
+            <TekstBlokk
+              tekstblokk={tekster.tittel}
+              typografi={TypografiTyper.StegHeadingH1}
+            />
+            <VeilederHilsen innhold={tekster.veilederhilsenInnhold} />
+          </>
+        )}
       </div>
     </div>
   );

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -5,7 +5,11 @@ import { useLoaderData } from '@remix-run/react';
 import { createClient } from '@sanity/client';
 import React from 'react';
 import VeilederHilsen from '../komponenter/veilederhilsen/veilederhilsen';
-import { ESanityApiKey, SanityDokument } from '~/typer/sanity/sanity';
+import {
+  ESanityApiKey,
+  LocaleType,
+  SanityDokument,
+} from '~/typer/sanity/sanity';
 import TekstBlokk from '~/komponenter/tekstBlokk/tekstBlokk';
 import { TypografiTyper } from '~/typer/typografi';
 //import { LocaleType, Sprakvelger } from '@navikt/familie-sprakvelger';
@@ -37,22 +41,30 @@ export const loader = async () => {
 
 export default function Index() {
   const { forsideTekst } = useLoaderData<typeof loader>();
+  const spraak: LocaleType = LocaleType.nb;
 
   const dokumenter: Map<ESanityApiKey, SanityDokument> = new Map();
   forsideTekst.map(dokument => dokumenter.set(dokument.api_navn, dokument));
 
   const punktlisteDokument = dokumenter.get(ESanityApiKey.PUNKTLISTE);
+  const tittelPunktlisteDokument = dokumenter.get(
+    ESanityApiKey.TITTEL_PUNKTLISTE,
+  );
 
   return (
     <div className={`${css.sentrerTekst} ${css.fyllSide}`}>
       <div className={`${css.innholdkonteiner}`}>
         <TekstBlokk
           tekstblokk={dokumenter.get(ESanityApiKey.TITTEL)}
-          valgBlock="nb"
+          valgBlock={spraak}
           typografi={TypografiTyper.StegHeadingH1}
         />
 
-        <VeilederHilsen dokument={punktlisteDokument} />
+        <VeilederHilsen
+          punktlisteDokument={punktlisteDokument}
+          tittelPunktlisteDokument={tittelPunktlisteDokument}
+          spraak={spraak}
+        />
       </div>
     </div>
   );

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -6,6 +6,8 @@ import { createClient } from '@sanity/client';
 import React from 'react';
 import VeilederHilsen from '../komponenter/veilederhilsen/veilederhilsen';
 import { ESanityApiKey, SanityDokument } from '~/typer/sanity/sanity';
+import TekstBlokk from '~/komponenter/tekstBlokk/tekstBlokk';
+import { TypografiTyper } from '~/typer/typografi';
 //import { LocaleType, Sprakvelger } from '@navikt/familie-sprakvelger';
 
 export const meta: V2_MetaFunction = () => {
@@ -45,12 +47,13 @@ export default function Index() {
     <div className={`${css.sentrerTekst} ${css.fyllSide}`}>
       <div className={`${css.innholdkonteiner}`}>
         <Heading level="1" size="xlarge">
-          {/*       {     tittel ? tittel[0].nb[0].children[0].text : 'Sanity funker ikke'}
-           */}{' '}
+          <TekstBlokk
+            tekstblokk={dokumenter.get(ESanityApiKey.TITTEL)}
+            valgBlock="nn"
+            typografi={TypografiTyper.StegHeadingH1}
+          />
         </Heading>
         <VeilederHilsen />
-        {/*         <p>{punktliste ? punktliste[0].nb[0].children[0].text :"Ingen punktliste her"}</p>
-         */}{' '}
       </div>
     </div>
   );

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,18 +1,11 @@
 import type { V2_MetaFunction } from '@remix-run/node';
-import { Heading } from '@navikt/ds-react';
 import css from './_index.module.css';
-import { useLoaderData } from '@remix-run/react';
-import { createClient } from '@sanity/client';
 import React from 'react';
 import VeilederHilsen from '../komponenter/veilederhilsen/veilederhilsen';
-import {
-  ESanityApiKey,
-  LocaleType,
-  SanityDokument,
-} from '~/typer/sanity/sanity';
+import { ESanitySteg } from '~/typer/sanity/sanity';
 import TekstBlokk from '~/komponenter/tekstBlokk/tekstBlokk';
 import { TypografiTyper } from '~/typer/typografi';
-//import { LocaleType, Sprakvelger } from '@navikt/familie-sprakvelger';
+import { useTekster } from '~/utils/sanityLoader';
 
 export const meta: V2_MetaFunction = () => {
   return [
@@ -25,46 +18,18 @@ export const meta: V2_MetaFunction = () => {
   ];
 };
 
-const sanityKlient = createClient({
-  projectId: 'd8ycstqz',
-  dataset: 'production',
-  apiVersion: '2021-10-21',
-  useCdn: true,
-});
-
-export const loader = async () => {
-  const forsideTekst = await sanityKlient.fetch<SanityDokument[]>(
-    '*[steg == "FORSIDE"]',
-  );
-  return { forsideTekst };
-};
-
 export default function Index() {
-  const { forsideTekst } = useLoaderData<typeof loader>();
-  const spraak: LocaleType = LocaleType.nb;
-
-  const dokumenter: Map<ESanityApiKey, SanityDokument> = new Map();
-  forsideTekst.map(dokument => dokumenter.set(dokument.api_navn, dokument));
-
-  const punktlisteDokument = dokumenter.get(ESanityApiKey.PUNKTLISTE);
-  const tittelPunktlisteDokument = dokumenter.get(
-    ESanityApiKey.TITTEL_PUNKTLISTE,
-  );
+  const tekster = useTekster(ESanitySteg.FORSIDE);
+  console.log(tekster);
 
   return (
     <div className={`${css.sentrerTekst} ${css.fyllSide}`}>
       <div className={`${css.innholdkonteiner}`}>
         <TekstBlokk
-          tekstblokk={dokumenter.get(ESanityApiKey.TITTEL)}
-          valgBlock={spraak}
+          tekstblokk={tekster.tittel}
           typografi={TypografiTyper.StegHeadingH1}
         />
-
-        <VeilederHilsen
-          punktlisteDokument={punktlisteDokument}
-          tittelPunktlisteDokument={tittelPunktlisteDokument}
-          spraak={spraak}
-        />
+        <VeilederHilsen innhold={tekster.veilederhilsenInnhold} />
       </div>
     </div>
   );

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -5,6 +5,8 @@ import { useLoaderData } from '@remix-run/react';
 import { createClient } from '@sanity/client';
 import React from 'react';
 import VeilederHilsen from '../komponenter/veilederhilsen/veilederhilsen';
+import { ESanityApiKey, SanityDokument } from '~/typer/sanity/sanity';
+//import { LocaleType, Sprakvelger } from '@navikt/familie-sprakvelger';
 
 export const meta: V2_MetaFunction = () => {
   return [
@@ -25,20 +27,30 @@ const sanityKlient = createClient({
 });
 
 export const loader = async () => {
-  const data = await sanityKlient.fetch('*');
-  return { data };
+  const forsideTekst = await sanityKlient.fetch<SanityDokument[]>(
+    '*[steg == "FORSIDE"]',
+  );
+  return { forsideTekst };
 };
 
 export default function Index() {
-  const { data } = useLoaderData<typeof loader>();
+  const { forsideTekst } = useLoaderData<typeof loader>();
+
+  const dokumenter: Map<ESanityApiKey, SanityDokument> = new Map();
+  forsideTekst.map(dokument => dokumenter.set(dokument.api_navn, dokument));
+
+  console.log(dokumenter.get(ESanityApiKey.TITTEL));
 
   return (
     <div className={`${css.sentrerTekst} ${css.fyllSide}`}>
-       <div className={`${css.innholdkonteiner}`}>
+      <div className={`${css.innholdkonteiner}`}>
         <Heading level="1" size="xlarge">
-          {data ? data[0].nb[0].children[0].text : 'Sanity funker ikke'}
+          {/*       {     tittel ? tittel[0].nb[0].children[0].text : 'Sanity funker ikke'}
+           */}{' '}
         </Heading>
         <VeilederHilsen />
+        {/*         <p>{punktliste ? punktliste[0].nb[0].children[0].text :"Ingen punktliste her"}</p>
+         */}{' '}
       </div>
     </div>
   );

--- a/app/typer/sanity/sanity.ts
+++ b/app/typer/sanity/sanity.ts
@@ -18,7 +18,7 @@ export enum CustomSanityTyper {
 
 export enum ESanityApiKey {
   TITTEL = 'tittelPaForside',
-  PUNKTLISTE = 'punktlistePaForside',
+  PUNKTLISTE = 'punktlisteMedEndringsgrunner',
 }
 
 export type TextBlock = Record<ESanityApiKey, string> & {

--- a/app/typer/sanity/sanity.ts
+++ b/app/typer/sanity/sanity.ts
@@ -1,0 +1,49 @@
+import { PortableTextBlock } from '@portabletext/types';
+
+export interface SanityDokument {
+  _createdAt: string;
+  _rev: string;
+  _type: string;
+  _id: string;
+  api_navn: ESanityApiKey;
+  visningsnavn: string;
+  nb: CustomSanityTyper.CUSTUM_BLOCK;
+  nn: CustomSanityTyper.CUSTUM_BLOCK;
+  en: CustomSanityTyper.CUSTUM_BLOCK;
+}
+
+export enum CustomSanityTyper {
+  CUSTUM_BLOCK = 'customBlock',
+}
+
+export enum ESanityApiKey {
+  TITTEL = 'tittelPaForside',
+  PUNKTLISTE = 'punktlistePaForside',
+}
+
+export type TextBlock = Record<ESanityApiKey, string> & {
+  api_navn: string;
+  [key: string]: unknown;
+};
+
+export interface IForsideTekstinnhold {
+  tittel: LocaleRecordString;
+  punktliste: LocaleRecordBlock;
+}
+
+//import { LocaleType } from '@navikt/familie-sprakvelger';
+export enum LocaleType {
+  en = 'en',
+  nb = 'nb',
+  nn = 'nn',
+}
+
+export type LocaleRecordString = Record<LocaleType, string> & {
+  api_navn: string;
+  [key: string]: unknown;
+};
+
+export type LocaleRecordBlock = Record<LocaleType, PortableTextBlock[]> & {
+  api_navn: string;
+  [key: string]: unknown;
+};

--- a/app/typer/sanity/sanity.ts
+++ b/app/typer/sanity/sanity.ts
@@ -5,47 +5,27 @@ export interface SanityDokument {
   _rev: string;
   _type: string;
   _id: string;
-  api_navn: ESanityApiKey;
-  visningsnavn: string;
-  /*  nb: CustomSanityTyper.CUSTUM_BLOCK;
-  nn: CustomSanityTyper.CUSTUM_BLOCK;
-  en: CustomSanityTyper.CUSTUM_BLOCK; */
-}
-
-/* export enum CustomSanityTyper {
-  CUSTUM_BLOCK = 'customBlock',
-} */
-
-export enum ESanityApiKey {
-  TITTEL = 'tittelPaForside',
-  PUNKTLISTE = 'punktlisteMedEndringsgrunner',
-  TITTEL_PUNKTLISTE = 'tittelPunktlisteMedEndringsgrunner',
-}
-
-export type TextBlock = Record<ESanityApiKey, string> & {
   api_navn: string;
-  [key: string]: unknown;
-};
-
-export interface IForsideTekstinnhold {
-  tittel: LocaleRecordString;
-  punktliste: LocaleRecordBlock;
+  visningsnavn: string;
+  steg: ESanitySteg;
+  ytelse: string;
+  nb: PortableTextBlock;
+  nn: PortableTextBlock;
+  en: PortableTextBlock;
 }
 
-//import { LocaleType } from '@navikt/familie-sprakvelger';
 export enum LocaleType {
   en = 'en',
   nb = 'nb',
   nn = 'nn',
 }
 
-//Ikke brukt enda, men notert at det er gjort i eksempel repo
-export type LocaleRecordString = Record<LocaleType, string> & {
-  api_navn: string;
-  [key: string]: unknown;
-};
+export enum ESanitySteg {
+  FORSIDE = 'FORSIDE',
+}
 
-export type LocaleRecordBlock = Record<LocaleType, PortableTextBlock[]> & {
-  api_navn: string;
-  [key: string]: unknown;
-};
+export type IForsideTekstinnhold = Record<string, SanityDokument>;
+
+export interface ITekstinnhold {
+  [ESanitySteg.FORSIDE]: IForsideTekstinnhold;
+}

--- a/app/typer/sanity/sanity.ts
+++ b/app/typer/sanity/sanity.ts
@@ -7,18 +7,19 @@ export interface SanityDokument {
   _id: string;
   api_navn: ESanityApiKey;
   visningsnavn: string;
-  nb: CustomSanityTyper.CUSTUM_BLOCK;
+  /*  nb: CustomSanityTyper.CUSTUM_BLOCK;
   nn: CustomSanityTyper.CUSTUM_BLOCK;
-  en: CustomSanityTyper.CUSTUM_BLOCK;
+  en: CustomSanityTyper.CUSTUM_BLOCK; */
 }
 
-export enum CustomSanityTyper {
+/* export enum CustomSanityTyper {
   CUSTUM_BLOCK = 'customBlock',
-}
+} */
 
 export enum ESanityApiKey {
   TITTEL = 'tittelPaForside',
   PUNKTLISTE = 'punktlisteMedEndringsgrunner',
+  TITTEL_PUNKTLISTE = 'tittelPunktlisteMedEndringsgrunner',
 }
 
 export type TextBlock = Record<ESanityApiKey, string> & {
@@ -38,6 +39,7 @@ export enum LocaleType {
   nn = 'nn',
 }
 
+//Ikke brukt enda, men notert at det er gjort i eksempel repo
 export type LocaleRecordString = Record<LocaleType, string> & {
   api_navn: string;
   [key: string]: unknown;

--- a/app/typer/typografi.ts
+++ b/app/typer/typografi.ts
@@ -1,0 +1,13 @@
+export enum TypografiTyper {
+  StegHeadingH1 = 'StegHeadingH1',
+  ModalHeadingH1 = 'ModalHeadingH1',
+  ForsideHeadingH1 = 'ForsideHeadingH1',
+  Ingress = 'Ingress',
+  BodyLong = 'BodyLong',
+  BodyShort = 'BodyShort',
+  Label = 'Label',
+  Detail = 'Detail',
+  Bold = 'Bold',
+  HeadingH2 = 'HeadingH2',
+  Liste = 'Liste',
+}

--- a/app/typer/typografi.ts
+++ b/app/typer/typografi.ts
@@ -1,14 +1,4 @@
 export enum TypografiTyper {
   StegHeadingH1 = 'StegHeadingH1',
-  ModalHeadingH1 = 'ModalHeadingH1',
-  ForsideHeadingH1 = 'ForsideHeadingH1',
-  Ingress = 'Ingress',
-  BodyLong = 'BodyLong',
   BodyShort = 'BodyShort',
-  Label = 'Label',
-  Detail = 'Detail',
-  Bold = 'Bold',
-  HeadingH2 = 'HeadingH2',
-  Liste = 'Liste',
-  Normal = 'Normal',
 }

--- a/app/typer/typografi.ts
+++ b/app/typer/typografi.ts
@@ -10,4 +10,5 @@ export enum TypografiTyper {
   Bold = 'Bold',
   HeadingH2 = 'HeadingH2',
   Liste = 'Liste',
+  Normal = 'Normal',
 }

--- a/app/utils/sanityLoader.ts
+++ b/app/utils/sanityLoader.ts
@@ -1,0 +1,41 @@
+import { useOutletContext } from '@remix-run/react';
+import { createClient } from '@sanity/client';
+import {
+  ESanitySteg,
+  ITekstinnhold,
+  SanityDokument,
+} from '~/typer/sanity/sanity';
+
+const sanityKlient = createClient({
+  projectId: 'd8ycstqz',
+  dataset: 'production',
+  apiVersion: '2021-10-21',
+  useCdn: true,
+});
+
+export const hentDataFraSanity = async (): Promise<ITekstinnhold> => {
+  const tekst = await sanityKlient.fetch<SanityDokument[]>(
+    '*[ytelse == "BARNETRYGD"]',
+  );
+
+  const tekstInnhold = {
+    [ESanitySteg.FORSIDE]: strukturerInnholdForSteg(tekst, ESanitySteg.FORSIDE),
+  };
+
+  return tekstInnhold;
+};
+
+const strukturerInnholdForSteg = (
+  dokumenter: SanityDokument[],
+  steg: ESanitySteg,
+): Record<string, SanityDokument> =>
+  dokumenter
+    .filter(dok => dok.steg === steg)
+    .reduce((acc, dok) => {
+      return { ...acc, [dok.api_navn]: dok };
+    }, {});
+
+export function useTekster(steg: ESanitySteg) {
+  const tekster = useOutletContext<ITekstinnhold>();
+  return tekster[steg];
+}

--- a/app/utils/typografiWrapper.tsx
+++ b/app/utils/typografiWrapper.tsx
@@ -1,0 +1,30 @@
+import { Heading } from '@navikt/ds-react';
+import { TypografiTyper } from '~/typer/typografi';
+
+export interface WrapperProps {
+  typografi?: TypografiTyper;
+  children?: React.ReactNode | React.ReactNode[];
+}
+
+export const TypografiWrapper: React.FC<WrapperProps> = ({
+  typografi,
+  children,
+}: WrapperProps) => {
+  switch (typografi) {
+    case TypografiTyper.Liste:
+      return <li>{children}</li>;
+
+    case TypografiTyper.StegHeadingH1:
+      return (
+        <Heading level="1" size="xlarge">
+          {children}
+        </Heading>
+      );
+
+    case TypografiTyper.Bold:
+      return <b>{children}</b>;
+
+    case undefined:
+      return <div>{children}</div>;
+  }
+};

--- a/app/utils/typografiWrapper.tsx
+++ b/app/utils/typografiWrapper.tsx
@@ -1,23 +1,20 @@
-import { Heading } from '@navikt/ds-react';
+import { BodyShort, Heading } from '@navikt/ds-react';
 import { TypografiTyper } from '~/typer/typografi';
 
-export interface WrapperProps {
+export interface Props {
   typografi?: TypografiTyper;
   children?: React.ReactNode | React.ReactNode[];
   style?: React.CSSProperties;
 }
 
-export const TypografiWrapper: React.FC<WrapperProps> = ({
+export const TypografiWrapper: React.FC<Props> = ({
   typografi,
   children,
   style,
-}: WrapperProps) => {
+}: Props) => {
   switch (typografi) {
-    case TypografiTyper.Liste:
-      return <li>{children}</li>;
-
-    case TypografiTyper.Normal:
-      return <p style={style}>{children}</p>;
+    case TypografiTyper.BodyShort:
+      return <BodyShort style={style}>{children}</BodyShort>;
 
     case TypografiTyper.StegHeadingH1:
       return (
@@ -26,13 +23,7 @@ export const TypografiWrapper: React.FC<WrapperProps> = ({
         </Heading>
       );
 
-    case TypografiTyper.Bold:
-      return <b style={style}>{children}</b>;
-
-    case undefined:
-      return <div style={style}>{children}</div>;
-
     default:
-      return <div>{children}</div>;
+      return <div style={style}>{children}</div>;
   }
 };

--- a/app/utils/typografiWrapper.tsx
+++ b/app/utils/typografiWrapper.tsx
@@ -4,27 +4,35 @@ import { TypografiTyper } from '~/typer/typografi';
 export interface WrapperProps {
   typografi?: TypografiTyper;
   children?: React.ReactNode | React.ReactNode[];
+  style?: React.CSSProperties;
 }
 
 export const TypografiWrapper: React.FC<WrapperProps> = ({
   typografi,
   children,
+  style,
 }: WrapperProps) => {
   switch (typografi) {
     case TypografiTyper.Liste:
       return <li>{children}</li>;
 
+    case TypografiTyper.Normal:
+      return <p style={style}>{children}</p>;
+
     case TypografiTyper.StegHeadingH1:
       return (
-        <Heading level="1" size="xlarge">
+        <Heading style={style} level="1" size="xlarge">
           {children}
         </Heading>
       );
 
     case TypografiTyper.Bold:
-      return <b>{children}</b>;
+      return <b style={style}>{children}</b>;
 
     case undefined:
+      return <div style={style}>{children}</div>;
+
+    default:
       return <div>{children}</div>;
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@remix-run/react": "^1.17.0",
         "@remix-run/serve": "^1.17.0",
         "@sanity/client": "^6.1.3",
+        "eslint-plugin-unused-imports": "^2.0.0",
         "isbot": "^3.6.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -2262,7 +2263,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
       "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
-      "dev": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
       },
@@ -2277,7 +2277,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
       "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -2289,7 +2288,6 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
       "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
-      "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -2298,7 +2296,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
       "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
-      "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -2321,7 +2318,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2331,7 +2327,6 @@
       "version": "13.20.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
       "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
-      "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -2346,7 +2341,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2358,7 +2352,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -2370,7 +2363,6 @@
       "version": "8.42.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.42.0.tgz",
       "integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -2423,7 +2415,6 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
       "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
-      "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -2437,7 +2428,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2447,7 +2437,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2459,7 +2448,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -2471,8 +2459,7 @@
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "dev": true
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
@@ -3363,7 +3350,7 @@
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -3448,7 +3435,7 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/unist": {
       "version": "2.0.6",
@@ -3459,7 +3446,7 @@
       "version": "5.59.9",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.9.tgz",
       "integrity": "sha512-4uQIBq1ffXd2YvF7MAvehWKW3zVv/w+mSfRAu+8cKbfj3nwzyqJLNcZJpQ/WZ1HLbJDiowwmQ6NO+63nCA+fqA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.59.9",
@@ -3493,7 +3480,7 @@
       "version": "5.59.9",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.9.tgz",
       "integrity": "sha512-FsPkRvBtcLQ/eVK1ivDiNYBjn3TGJdXy2fhXX+rc7czWl4ARwnpArwbihSOHI2Peg9WbtGHrbThfBUkZZGTtvQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.59.9",
         "@typescript-eslint/types": "5.59.9",
@@ -3520,7 +3507,7 @@
       "version": "5.59.9",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.9.tgz",
       "integrity": "sha512-8RA+E+w78z1+2dzvK/tGZ2cpGigBZ58VMEHDZtpE1v+LLjzrYGc8mMaTONSxKyEkz3IuXFM0IqYiGHlCsmlZxQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@typescript-eslint/types": "5.59.9",
         "@typescript-eslint/visitor-keys": "5.59.9"
@@ -3537,7 +3524,7 @@
       "version": "5.59.9",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.9.tgz",
       "integrity": "sha512-ksEsT0/mEHg9e3qZu98AlSrONAQtrSTljL3ow9CGej8eRo7pe+yaC/mvTjptp23Xo/xIf2mLZKC6KPv4Sji26Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@typescript-eslint/typescript-estree": "5.59.9",
         "@typescript-eslint/utils": "5.59.9",
@@ -3564,7 +3551,7 @@
       "version": "5.59.9",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.9.tgz",
       "integrity": "sha512-uW8H5NRgTVneSVTfiCVffBb8AbwWSKg7qcA4Ot3JI3MPCJGsB4Db4BhvAODIIYE5mNj7Q+VJkK7JxmRhk2Lyjw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -3577,7 +3564,7 @@
       "version": "5.59.9",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.9.tgz",
       "integrity": "sha512-pmM0/VQ7kUhd1QyIxgS+aRvMgw+ZljB3eDb+jYyp6d2bC0mQWLzUDF+DLwCTkQ3tlNyVsvZRXjFyV0LkU/aXjA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@typescript-eslint/types": "5.59.9",
         "@typescript-eslint/visitor-keys": "5.59.9",
@@ -3604,7 +3591,7 @@
       "version": "5.59.9",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.9.tgz",
       "integrity": "sha512-1PuMYsju/38I5Ggblaeb98TOoUvjhRvLpLa1DoTOFaLWqaXl/1iQ1eGurTXgBY58NUdtfTXKP5xBq7q9NDaLKg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
@@ -3630,7 +3617,7 @@
       "version": "5.59.9",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.9.tgz",
       "integrity": "sha512-bT7s0td97KMaLwpEBckbzj/YohnvXtqbe2XgqNvTl6RJVakY5mvENOTPvw5u66nljfZxthESpDozs86U+oLY8Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@typescript-eslint/types": "5.59.9",
         "eslint-visitor-keys": "^3.3.0"
@@ -3647,7 +3634,7 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
       "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -3799,7 +3786,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4460,7 +4446,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5310,7 +5295,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -5605,7 +5589,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -5702,7 +5685,6 @@
       "version": "8.42.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.42.0.tgz",
       "integrity": "sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==",
-      "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -6286,11 +6268,39 @@
         "eslint": "^7.5.0 || ^8.0.0"
       }
     },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
+      "integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+      "dependencies": {
+        "eslint-rule-composer": "^0.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "eslint": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -6303,7 +6313,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -6345,7 +6355,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6355,7 +6364,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
       "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
-      "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -6371,7 +6379,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
       "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -6383,7 +6390,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -6395,7 +6401,6 @@
       "version": "13.20.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
       "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
-      "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -6410,7 +6415,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6422,7 +6426,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -6434,7 +6437,6 @@
       "version": "9.5.2",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
       "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
-      "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
@@ -6451,7 +6453,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
       "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -6475,7 +6476,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
       "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
-      "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -6487,7 +6487,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -6499,7 +6498,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -6789,8 +6787,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -6816,8 +6813,7 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -6870,7 +6866,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "dev": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -6946,7 +6941,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-      "dev": true,
       "dependencies": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
@@ -6958,8 +6952,7 @@
     "node_modules/flatted": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-      "dev": true
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.2",
@@ -7415,7 +7408,7 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -7475,13 +7468,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
     },
     "node_modules/gunzip-maybe": {
       "version": "1.4.2",
@@ -7760,7 +7752,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -8198,7 +8189,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8473,14 +8463,12 @@
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -8557,7 +8545,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -8823,8 +8810,7 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -10026,14 +10012,13 @@
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
     },
     "node_modules/natural-compare-lite": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -10294,7 +10279,6 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
       "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-      "dev": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -10441,7 +10425,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -10754,7 +10737,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -10939,7 +10921,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -11371,7 +11352,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -12065,7 +12045,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -12200,8 +12179,7 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -12335,7 +12313,7 @@
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
       "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "tslib": "^1.8.1"
       },
@@ -12350,7 +12328,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -12367,7 +12345,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -12416,7 +12393,7 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
       "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12693,7 +12670,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@navikt/ds-css": "^3.3.1",
         "@navikt/ds-react": "^3.3.1",
         "@navikt/ds-tokens": "^3.3.1",
+        "@portabletext/react": "^3.0.2",
         "@portabletext/types": "^2.0.2",
         "@remix-run/css-bundle": "^1.17.0",
         "@remix-run/node": "^1.17.0",
@@ -2672,6 +2673,32 @@
       },
       "engines": {
         "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@portabletext/react": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@portabletext/react/-/react-3.0.2.tgz",
+      "integrity": "sha512-uZVWXzN69Ql98ja5zmb8vIGHY4Y0jFWoMArgLcBdLJe6ia69vyYmPmUoLbkBqfH+FhWmsfLQMjgOC88q4OPaDw==",
+      "dependencies": {
+        "@portabletext/toolkit": "^2.0.1",
+        "@portabletext/types": "^2.0.2"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18"
+      }
+    },
+    "node_modules/@portabletext/toolkit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-2.0.1.tgz",
+      "integrity": "sha512-vr2SeDFUFV+VmRIyYsHBMimZLiiN0S7qIridt/YLJs3Wm1dI4jsfUam82AQwheSMjvWdBiBZ+Wsjq5HZBG4htw==",
+      "dependencies": {
+        "@portabletext/types": "^2.0.0"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@portabletext/types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@navikt/ds-css": "^3.3.1",
         "@navikt/ds-react": "^3.3.1",
         "@navikt/ds-tokens": "^3.3.1",
+        "@portabletext/types": "^2.0.2",
         "@remix-run/css-bundle": "^1.17.0",
         "@remix-run/node": "^1.17.0",
         "@remix-run/react": "^1.17.0",
@@ -2671,6 +2672,14 @@
       },
       "engines": {
         "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@portabletext/types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@portabletext/types/-/types-2.0.2.tgz",
+      "integrity": "sha512-3xTbSa80G1nODyACY0ilrmPo1PmU1xuoPvfcpzpqSEL0kX01fSW+21PKgS9BcG+GqdG9HK/VxciKWa+nFA7mqg==",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0 || >=18.0.0"
       }
     },
     "node_modules/@radix-ui/primitive": {

--- a/package.json
+++ b/package.json
@@ -12,12 +12,6 @@
     "lint-staged": "lint-staged",
     "prepare": "husky install"
   },
-  "lint-staged": {
-    "src/**/*.{js,jsx,ts,tsx,json,css}": [
-      "prettier --write",
-      "eslint --fix --max-warnings=0"
-    ]
-  },
   "eslintIgnore": [
     "/node_modules",
     "/build",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@navikt/ds-css": "^3.3.1",
     "@navikt/ds-react": "^3.3.1",
     "@navikt/ds-tokens": "^3.3.1",
+    "@portabletext/types": "^2.0.2",
     "@remix-run/css-bundle": "^1.17.0",
     "@remix-run/node": "^1.17.0",
     "@remix-run/react": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "remix dev",
     "start": "remix-serve build",
     "typecheck": "tsc",
-    "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
+    "lint": "eslint --max-warnings=0 --cache --cache-location ./node_modules/.cache/eslint .",
     "lint-staged": "lint-staged",
     "prepare": "husky install"
   },
@@ -29,6 +29,7 @@
     "@remix-run/react": "^1.17.0",
     "@remix-run/serve": "^1.17.0",
     "@sanity/client": "^6.1.3",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "isbot": "^3.6.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@navikt/ds-css": "^3.3.1",
     "@navikt/ds-react": "^3.3.1",
     "@navikt/ds-tokens": "^3.3.1",
+    "@portabletext/react": "^3.0.2",
     "@portabletext/types": "^2.0.2",
     "@remix-run/css-bundle": "^1.17.0",
     "@remix-run/node": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
     "lint-staged": "lint-staged",
     "prepare": "husky install"
   },
+  "lint-staged": {
+    "src/**/*.{js,jsx,ts,tsx,json,css}": [
+      "prettier --write",
+      "eslint --fix --max-warnings=0"
+    ]
+  },
   "eslintIgnore": [
     "/node_modules",
     "/build",


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
For at brukere kan se en liste av endringsmeldingsgrunner på forsiden, og for at man kan hente teksten til dette for 3 forskjellige språk. 

[Lenke til trello kort](https://trello.com/c/jPlSif3O/23-legg-til-puktliste-tekst-for-veilederhilsen)

### Hvordan er det løst? 🧠
Henter all tekst for forsiden og legger det i en key, value map for at teksten kan hentes utifra api_key. Teksten vises da ved å bruke en tekstblokk som bruker portable tekst, som igjen bruker en tekst-wrapper for å håndtere ulike typografier. 
Språkvalg for alle komponenter er håndtert med en egen variabel i index filen som senere kan kobles til en språkvelger. 
Koden er inspirert av ks-soknad repoet [her](https://github.com/navikt/familie-ks-soknad/blob/69e40d535d9dfb8f80c10b1c0e693f1329397d29/src/frontend/components/Felleskomponenter/TekstBlock.tsx)

Bilde viser framsiden med engelsk språkvalg:
![Screenshot 2023-06-19 at 11 09 46](https://github.com/bekk/nav-familie-endringsmelding/assets/54811230/fbb627cc-1dda-44a8-9f4b-287a42b2bc7d)
