### PR TITLE
Link til personvernerklæring

### DIFF
--- a/app/komponenter/tekstBlokk/tekstBlokk.tsx
+++ b/app/komponenter/tekstBlokk/tekstBlokk.tsx
@@ -28,6 +28,19 @@ const TekstBlokk: React.FC<Props> = ({ tekstblokk, typografi }: Props) => {
             </TypografiWrapper>
           ),
         },
+        marks: {
+          link: props => {
+            return (
+              <a
+                target={props.value.blank ? '_blank' : '_self'}
+                href={encodeURI(props.value.href)}
+                rel="noreferrer"
+              >
+                {props.text}
+              </a>
+            );
+          },
+        },
       }}
     />
   ) : null;

--- a/app/komponenter/veilederhilsen/veilederhilsen.module.css
+++ b/app/komponenter/veilederhilsen/veilederhilsen.module.css
@@ -1,5 +1,6 @@
 .poster {
   text-align: left;
+  width: 100%;
 }
 
 .poster ul {

--- a/app/routes/_index.module.css
+++ b/app/routes/_index.module.css
@@ -22,47 +22,6 @@
   }
 }
 
-.regnbue {
-  animation: rainbow 2.5s linear;
-  animation-iteration-count: infinite;
-}
-
-@keyframes rainbow {
-  100%,
-  0% {
-    color: rgb(255, 0, 0);
-  }
-  8% {
-    color: rgb(255, 127, 0);
-  }
-  16% {
-    color: rgb(255, 255, 0);
-  }
-  25% {
-    color: rgb(127, 255, 0);
-  }
-  33% {
-    color: rgb(0, 255, 0);
-  }
-  41% {
-    color: rgb(0, 255, 127);
-  }
-  50% {
-    color: rgb(0, 255, 255);
-  }
-  58% {
-    color: rgb(0, 127, 255);
-  }
-  66% {
-    color: rgb(0, 0, 255);
-  }
-  75% {
-    color: rgb(127, 0, 255);
-  }
-  83% {
-    color: rgb(255, 0, 255);
-  }
-  91% {
-    color: rgb(255, 0, 127);
-  }
+.personvernerklaeringLink {
+  margin-top: 15rem;
 }

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -34,6 +34,11 @@ export default function Index() {
               typografi={TypografiTyper.StegHeadingH1}
             />
             <VeilederHilsen innhold={tekster.veilederhilsenInnhold} />
+            <div className={`${css.personvernerklaeringLink}`}>
+              <TekstBlokk
+                tekstblokk={tekster.linkTilPersonvernerklaering}
+              ></TekstBlokk>
+            </div>
           </>
         )}
       </div>


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
Vi vil vise en lenke til Nav sin side om personopplysninger. Siden skal åpnes i ny fane slik at søker ikke mister det jobber med 

[Lenke til trello kort](https://trello.com/c/h1EhogG1/26-legge-til-personopplysningslenke-som-åpnes-i-nytt-vindu)

### Hvordan er det løst? 🧠

Vi har lagt til ny link i sanity, med teksten til link og brukt eksternlenke i sanity for å legge inn url-en som går til personopplysninger.

Brukte teksblokk til å sette linken og la til marks med link i textblokk komponenter.

Bilde til resultatet:
<img width="711" alt="Screenshot 2023-06-20 at 13 06 11" src="https://github.com/bekk/nav-familie-endringsmelding/assets/31205453/00efe9b2-36d7-4cd8-a6a3-aa954e747ce6">
