### PR TITLE
Flettefelt med data

### DIFF
--- a/app/komponenter/tekstBlokk/tekstBlokk.tsx
+++ b/app/komponenter/tekstBlokk/tekstBlokk.tsx
@@ -2,11 +2,7 @@ import type { TypografiTyper } from '~/typer/typografi';
 import React from 'react';
 import { PortableText } from '@portabletext/react';
 import { TypografiWrapper } from '~/utils/typografiWrapper';
-import {
-  ESanityFlettefeltverdi,
-  LocaleType,
-  SanityDokument,
-} from '~/typer/sanity/sanity';
+import { LocaleType, SanityDokument } from '~/typer/sanity/sanity';
 import { flettefeltTilTekst } from '~/utils/fletteTilTekst';
 
 interface Props {
@@ -47,12 +43,7 @@ const TekstBlokk: React.FC<Props> = ({
           flettefelt: props => {
             if (props?.value?.flettefeltVerdi) {
               return (
-                <span>
-                  {flettefeltTilTekst(
-                    props?.value?.flettefeltVerdi,
-                    ESanityFlettefeltverdi.SØKER_NAVN,
-                  )}
-                </span>
+                <span>{flettefeltTilTekst(props?.value?.flettefeltVerdi)}</span>
               );
             } else {
               throw new Error(`Fant ikke flettefeltVerdi`);

--- a/app/komponenter/tekstBlokk/tekstBlokk.tsx
+++ b/app/komponenter/tekstBlokk/tekstBlokk.tsx
@@ -44,8 +44,6 @@ const TekstBlokk: React.FC<Props> = ({ tekstblokk, typografi }: Props) => {
               throw new Error(`Fant ikke flettefeltVerdi`);
             }
           },
-        },
-        marks: {
           link: props => {
             return (
               <a

--- a/app/komponenter/tekstBlokk/tekstBlokk.tsx
+++ b/app/komponenter/tekstBlokk/tekstBlokk.tsx
@@ -8,14 +8,9 @@ import { flettefeltTilTekst } from '~/utils/fletteTilTekst';
 interface Props {
   tekstblokk: SanityDokument | undefined;
   typografi?: TypografiTyper;
-  flettefelter?: TypografiTyper;
 }
 
-const TekstBlokk: React.FC<Props> = ({
-  tekstblokk,
-  typografi,
-  flettefelter,
-}: Props) => {
+const TekstBlokk: React.FC<Props> = ({ tekstblokk, typografi }: Props) => {
   const spraak: LocaleType = LocaleType.nb;
 
   return tekstblokk ? (

--- a/app/komponenter/tekstBlokk/tekstBlokk.tsx
+++ b/app/komponenter/tekstBlokk/tekstBlokk.tsx
@@ -2,14 +2,24 @@ import type { TypografiTyper } from '~/typer/typografi';
 import React from 'react';
 import { PortableText } from '@portabletext/react';
 import { TypografiWrapper } from '~/utils/typografiWrapper';
-import { LocaleType, SanityDokument } from '~/typer/sanity/sanity';
+import {
+  ESanityFlettefeltverdi,
+  LocaleType,
+  SanityDokument,
+} from '~/typer/sanity/sanity';
+import { flettefeltTilTekst } from '~/utils/fletteTilTekst';
 
 interface Props {
   tekstblokk: SanityDokument | undefined;
   typografi?: TypografiTyper;
+  flettefelter?: TypografiTyper;
 }
 
-const TekstBlokk: React.FC<Props> = ({ tekstblokk, typografi }: Props) => {
+const TekstBlokk: React.FC<Props> = ({
+  tekstblokk,
+  typografi,
+  flettefelter,
+}: Props) => {
   const spraak: LocaleType = LocaleType.nb;
 
   return tekstblokk ? (
@@ -27,6 +37,27 @@ const TekstBlokk: React.FC<Props> = ({ tekstblokk, typografi }: Props) => {
               {children}
             </TypografiWrapper>
           ),
+          h2: ({ children }) => (
+            <TypografiWrapper typografi={typografi}>
+              {children}
+            </TypografiWrapper>
+          ),
+        },
+        marks: {
+          flettefelt: props => {
+            if (props?.value?.flettefeltVerdi) {
+              return (
+                <span>
+                  {flettefeltTilTekst(
+                    props?.value?.flettefeltVerdi,
+                    ESanityFlettefeltverdi.SØKER_NAVN,
+                  )}
+                </span>
+              );
+            } else {
+              throw new Error(`Fant ikke flettefeltVerdi`);
+            }
+          },
         },
       }}
     />

--- a/app/komponenter/veilederhilsen/veilederhilsen.tsx
+++ b/app/komponenter/veilederhilsen/veilederhilsen.tsx
@@ -2,18 +2,32 @@ import { GuidePanel, Heading } from '@navikt/ds-react';
 import css from './veilederhilsen.module.css';
 import { SanityDokument } from '~/typer/sanity/sanity';
 import TekstBlokk from '../tekstBlokk/tekstBlokk';
+import søkerMock from '~/mock/søkerMock';
 
 interface VeilederHilsenProp {
   innhold: SanityDokument | undefined;
 }
 
+const hentSøkerFornavn = () => {
+  const søker = søkerMock;
+  //her skal vi fetche fra API
+  let fornavn: string = søker.visningsnavn.trim();
+  try {
+    fornavn = fornavn.split(' ')[0];
+  } catch (e) {
+    fornavn = '!';
+  }
+  return fornavn;
+};
+
 const VeilederHilsen: React.FC<VeilederHilsenProp> = ({
   innhold,
 }: VeilederHilsenProp) => {
+  const søkerFornavn = hentSøkerFornavn();
   return (
     <GuidePanel poster className={`${css.poster}`}>
       <Heading level="2" size="xlarge" className={`${css.tittelMargin}`}>
-        Hei [fornavn]
+        Hei {søkerFornavn}
       </Heading>
       <TekstBlokk tekstblokk={innhold} />
     </GuidePanel>

--- a/app/komponenter/veilederhilsen/veilederhilsen.tsx
+++ b/app/komponenter/veilederhilsen/veilederhilsen.tsx
@@ -1,34 +1,24 @@
-import { GuidePanel, Heading } from '@navikt/ds-react';
+import { GuidePanel } from '@navikt/ds-react';
 import css from './veilederhilsen.module.css';
 import { SanityDokument } from '~/typer/sanity/sanity';
 import TekstBlokk from '../tekstBlokk/tekstBlokk';
-import søkerMock from '~/mock/søkerMock';
+import { TypografiTyper } from '~/typer/typografi';
 
 interface VeilederHilsenProp {
   innhold: SanityDokument | undefined;
+  hilsen: SanityDokument | undefined;
 }
-
-const hentSøkerFornavn = () => {
-  const søker = søkerMock;
-  //her skal vi fetche fra API
-  let fornavn: string = søker.visningsnavn.trim();
-  try {
-    fornavn = fornavn.split(' ')[0];
-  } catch (e) {
-    fornavn = '!';
-  }
-  return fornavn;
-};
 
 const VeilederHilsen: React.FC<VeilederHilsenProp> = ({
   innhold,
+  hilsen,
 }: VeilederHilsenProp) => {
-  const søkerFornavn = hentSøkerFornavn();
   return (
     <GuidePanel poster className={`${css.poster}`}>
-      <Heading level="2" size="xlarge" className={`${css.tittelMargin}`}>
-        Hei {søkerFornavn}
-      </Heading>
+      <TekstBlokk
+        tekstblokk={hilsen}
+        typografi={TypografiTyper.StegHeadingH2}
+      />
       <TekstBlokk tekstblokk={innhold} />
     </GuidePanel>
   );

--- a/app/mock/søkerMock.ts
+++ b/app/mock/søkerMock.ts
@@ -2,7 +2,7 @@ import { ISøker } from '~/typer/søker';
 
 const søkerMock: ISøker = {
   ident: '12345678910',
-  visningsnavn: 'Søker mellomnavn Etternavn',
+  visningsnavn: 'Mock mellomnavn Etternavn',
 };
 
 export default søkerMock;

--- a/app/mock/søkerMock.ts
+++ b/app/mock/søkerMock.ts
@@ -1,0 +1,8 @@
+import { ISøker } from '~/typer/søker';
+
+const søkerMock: ISøker = {
+  ident: '12345678910',
+  visningsnavn: 'Kjetil mellomnavn Etternavn',
+};
+
+export default søkerMock;

--- a/app/mock/søkerMock.ts
+++ b/app/mock/søkerMock.ts
@@ -2,7 +2,7 @@ import { ISøker } from '~/typer/søker';
 
 const søkerMock: ISøker = {
   ident: '12345678910',
-  visningsnavn: 'Kjetil mellomnavn Etternavn',
+  visningsnavn: 'Søker mellomnavn Etternavn',
 };
 
 export default søkerMock;

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -33,7 +33,10 @@ export default function Index() {
               tekstblokk={tekster.tittel}
               typografi={TypografiTyper.StegHeadingH1}
             />
-            <VeilederHilsen innhold={tekster.veilederhilsenInnhold} />
+            <VeilederHilsen
+              innhold={tekster.veilederhilsenInnhold}
+              hilsen={tekster.brukerHilsen}
+            />
           </>
         )}
       </div>

--- a/app/typer/sanity/sanity.ts
+++ b/app/typer/sanity/sanity.ts
@@ -29,3 +29,7 @@ export type IForsideTekstinnhold = Record<string, SanityDokument>;
 export interface ITekstinnhold {
   [ESanitySteg.FORSIDE]: IForsideTekstinnhold;
 }
+
+export enum ESanityFlettefeltverdi {
+  SØKER_NAVN = 'SØKER_NAVN',
+}

--- a/app/typer/søker.ts
+++ b/app/typer/søker.ts
@@ -1,0 +1,4 @@
+export interface ISøker {
+  ident: string;
+  visningsnavn: string;
+}

--- a/app/typer/typografi.ts
+++ b/app/typer/typografi.ts
@@ -1,4 +1,5 @@
 export enum TypografiTyper {
   StegHeadingH1 = 'StegHeadingH1',
+  StegHeadingH2 = 'StegHeadingH2',
   BodyShort = 'BodyShort',
 }

--- a/app/utils/fletteTilTekst.ts
+++ b/app/utils/fletteTilTekst.ts
@@ -3,7 +3,6 @@ import { hentSøkerFornavn } from './hentFraApi';
 
 export const flettefeltTilTekst = (
   sanityFlettefelt: ESanityFlettefeltverdi,
-  flettefelter?: string,
 ): string => {
   switch (sanityFlettefelt) {
     case ESanityFlettefeltverdi.SØKER_NAVN:

--- a/app/utils/fletteTilTekst.ts
+++ b/app/utils/fletteTilTekst.ts
@@ -1,0 +1,12 @@
+import { ESanityFlettefeltverdi } from '~/typer/sanity/sanity';
+import { hentSøkerFornavn } from './hentFraApi';
+
+export const flettefeltTilTekst = (
+  sanityFlettefelt: ESanityFlettefeltverdi,
+  flettefelter?: string,
+): string => {
+  switch (sanityFlettefelt) {
+    case ESanityFlettefeltverdi.SØKER_NAVN:
+      return hentSøkerFornavn();
+  }
+};

--- a/app/utils/hentFraApi.ts
+++ b/app/utils/hentFraApi.ts
@@ -1,0 +1,13 @@
+import søkerMock from '~/mock/søkerMock';
+
+export const hentSøkerFornavn = () => {
+  const søker = søkerMock;
+  //her skal vi fetche fra API
+  let fornavn: string = søker.visningsnavn.trim();
+  try {
+    fornavn = fornavn.split(' ')[0];
+  } catch (e) {
+    fornavn = '!';
+  }
+  return fornavn;
+};

--- a/app/utils/hentFraApi.ts
+++ b/app/utils/hentFraApi.ts
@@ -6,7 +6,8 @@ export const hentSøkerFornavn = () => {
   let fornavn: string = søker.visningsnavn.trim();
   try {
     fornavn = fornavn.split(' ')[0];
-  } catch (e) {
+  } catch (e: unknown) {
+    console.log('❌ kunne ikke hente brukers navn: ', { e });
     fornavn = '!';
   }
   return fornavn;

--- a/app/utils/typografiWrapper.tsx
+++ b/app/utils/typografiWrapper.tsx
@@ -22,6 +22,12 @@ export const TypografiWrapper: React.FC<Props> = ({
           {children}
         </Heading>
       );
+    case TypografiTyper.StegHeadingH2:
+      return (
+        <Heading style={style} level="2" size="xlarge">
+          {children}
+        </Heading>
+      );
 
     default:
       return <div style={style}>{children}</div>;


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

For å sende en hilsen til brukeren, må en hente inn brukerens fornavn og legge dette til i hilsen i frontend
[Lenke til trello kort](https://trello.com/c/F1v3Mqn7/22-legge-til-fornavn-i-overskriften-til-veilederhilsen)

### Hvordan er det løst? 🧠
**Vi har ikke hentet ut fra API. Dette er en litt for omfattende prosess, og er lagt ut som en egen oppgave på Trello**
Det er opprettet et flettefelt i Sanity, som er lagt til som SØKER_NAVN på "Hilsen til Bruker". For å benytte dette er det lagd en mock som stemmer overens med dataen fra API-et, so kalles på. For å bytte ut mock med data, er det lagt til rette for å legge fetch-metoder i hentFraApi.ts.

Mock-data:
![Screenshot 2023-06-20 at 13 09 24](https://github.com/bekk/nav-familie-endringsmelding/assets/69514415/93ef81f6-86a0-4ddd-b147-a54155cff554)

Data fra API:
<img width="1414" alt="Screenshot 2023-06-20 at 13 14 16" src="https://github.com/bekk/nav-familie-endringsmelding/assets/69514415/ac366ae4-cf88-493c-8669-34f1e73c7eb7">
