### PR TITLE
Språkvelger

### DIFF
--- a/app/komponenter/språkvelger/språkvelger.module.css
+++ b/app/komponenter/språkvelger/språkvelger.module.css
@@ -1,0 +1,3 @@
+.språkvelger {
+  width: 10.75rem;
+}

--- a/app/komponenter/språkvelger/språkvelger.module.css
+++ b/app/komponenter/språkvelger/språkvelger.module.css
@@ -1,3 +1,8 @@
 .språkvelger {
   width: 10.75rem;
 }
+
+.label {
+  display: flex;
+  gap: 0.3rem;
+}

--- a/app/komponenter/språkvelger/språkvelger.tsx
+++ b/app/komponenter/språkvelger/språkvelger.tsx
@@ -7,18 +7,13 @@ import { GlobeIcon } from '@navikt/aksel-icons';
 export const Språkvelger = () => {
   const [, settSpråk] = useSpråk();
 
-  function endreSpråk(endring: React.ChangeEvent<HTMLSelectElement>) {
-    const endringVerdi = endring.target.value as LocaleType;
-    settSpråk(endringVerdi);
-  }
-
   return (
     <>
       <Select
         label={<Label />}
         className={`${css.språkvelger}`}
         onChange={endring => {
-          endreSpråk(endring);
+          settSpråk(endring.target.value as LocaleType);
         }}
       >
         <option value={LocaleType.nb}>Norsk (Bokmål)</option>

--- a/app/komponenter/språkvelger/språkvelger.tsx
+++ b/app/komponenter/språkvelger/språkvelger.tsx
@@ -13,19 +13,26 @@ export const Språkvelger = () => {
 
   return (
     <>
-      <GlobeIcon title="a11y-title" />
       <Select
-        label=""
-        hideLabel
+        label={<Label />}
         className={`${css.språkvelger}`}
         onChange={evt => {
           handleChange(evt);
         }}
       >
-        <option value={LocaleType.nb}> Bokmål</option>
-        <option value={LocaleType.nn}>Nynorsk</option>
+        <option value={LocaleType.nb}>Norsk (Bokmål)</option>
+        <option value={LocaleType.nn}>Norsk (Nynorsk)</option>
         <option value={LocaleType.en}>English</option>
       </Select>
     </>
+  );
+};
+
+const Label = () => {
+  return (
+    <div className={`${css.label}`}>
+      <GlobeIcon title="a11y-title" fontSize={'1.5rem'} />
+      <span> Språk/language </span>
+    </div>
   );
 };

--- a/app/komponenter/språkvelger/språkvelger.tsx
+++ b/app/komponenter/språkvelger/språkvelger.tsx
@@ -1,0 +1,31 @@
+import { Select } from '@navikt/ds-react';
+import { useSpråk } from '~/root';
+import { LocaleType } from '~/typer/sanity/sanity';
+import css from './språkvelger.module.css';
+import { GlobeIcon } from '@navikt/aksel-icons';
+
+export const Språkvelger = () => {
+  const [, settSpråk] = useSpråk();
+
+  function handleChange(evt: React.ChangeEvent<HTMLSelectElement>) {
+    settSpråk(evt.target.value as LocaleType);
+  }
+
+  return (
+    <>
+      <GlobeIcon title="a11y-title" />
+      <Select
+        label=""
+        hideLabel
+        className={`${css.språkvelger}`}
+        onChange={evt => {
+          handleChange(evt);
+        }}
+      >
+        <option value={LocaleType.nb}> Bokmål</option>
+        <option value={LocaleType.nn}>Nynorsk</option>
+        <option value={LocaleType.en}>English</option>
+      </Select>
+    </>
+  );
+};

--- a/app/komponenter/språkvelger/språkvelger.tsx
+++ b/app/komponenter/språkvelger/språkvelger.tsx
@@ -7,8 +7,9 @@ import { GlobeIcon } from '@navikt/aksel-icons';
 export const Språkvelger = () => {
   const [, settSpråk] = useSpråk();
 
-  function handleChange(evt: React.ChangeEvent<HTMLSelectElement>) {
-    settSpråk(evt.target.value as LocaleType);
+  function endreSpråk(endring: React.ChangeEvent<HTMLSelectElement>) {
+    const endringVerdi = endring.target.value as LocaleType;
+    settSpråk(endringVerdi);
   }
 
   return (
@@ -16,8 +17,8 @@ export const Språkvelger = () => {
       <Select
         label={<Label />}
         className={`${css.språkvelger}`}
-        onChange={evt => {
-          handleChange(evt);
+        onChange={endring => {
+          endreSpråk(endring);
         }}
       >
         <option value={LocaleType.nb}>Norsk (Bokmål)</option>

--- a/app/komponenter/tekstBlokk/tekstBlokk.tsx
+++ b/app/komponenter/tekstBlokk/tekstBlokk.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { PortableText } from '@portabletext/react';
 import { TypografiWrapper } from '~/utils/typografiWrapper';
 import { SanityDokument } from '~/typer/sanity/sanity';
-import { useSpraak } from '~/root';
+import { useSpråk } from '~/root';
 
 interface Props {
   tekstblokk: SanityDokument | undefined;
@@ -11,11 +11,11 @@ interface Props {
 }
 
 const TekstBlokk: React.FC<Props> = ({ tekstblokk, typografi }: Props) => {
-  const [spraak] = useSpraak();
+  const [språk] = useSpråk();
 
   return tekstblokk ? (
     <PortableText
-      value={tekstblokk[spraak]}
+      value={tekstblokk[språk]}
       components={{
         block: {
           normal: ({ children }) => (

--- a/app/komponenter/tekstBlokk/tekstBlokk.tsx
+++ b/app/komponenter/tekstBlokk/tekstBlokk.tsx
@@ -2,7 +2,8 @@ import type { TypografiTyper } from '~/typer/typografi';
 import React from 'react';
 import { PortableText } from '@portabletext/react';
 import { TypografiWrapper } from '~/utils/typografiWrapper';
-import { LocaleType, SanityDokument } from '~/typer/sanity/sanity';
+import { SanityDokument } from '~/typer/sanity/sanity';
+import { useSpraak } from '~/root';
 
 interface Props {
   tekstblokk: SanityDokument | undefined;
@@ -10,7 +11,7 @@ interface Props {
 }
 
 const TekstBlokk: React.FC<Props> = ({ tekstblokk, typografi }: Props) => {
-  const spraak: LocaleType = LocaleType.nb;
+  const [spraak] = useSpraak();
 
   return tekstblokk ? (
     <PortableText

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -26,8 +26,8 @@ export const loader: LoaderFunction = async () => {
 
 export default function App() {
   const data = useLoaderData<typeof loader>();
-  const [spraak, settSpraak] = useState<LocaleType>(LocaleType.nb);
-  console.log(spraak);
+  const [språk, settSpråk] = useState<LocaleType>(LocaleType.nb);
+
   return (
     <html lang="en">
       <head>
@@ -37,9 +37,7 @@ export default function App() {
         <Links />
       </head>
       <body>
-        <Outlet
-          context={{ sanityTekster: data, spraak: [spraak, settSpraak] }}
-        />
+        <Outlet context={{ sanityTekster: data, språk: [språk, settSpråk] }} />
         <ScrollRestoration />
         <Scripts />
         <LiveReload />
@@ -48,7 +46,7 @@ export default function App() {
   );
 }
 
-export function useSpraak() {
-  const { spraak } = useOutletContext<AppContex>();
-  return spraak;
+export function useSpråk() {
+  const { språk } = useOutletContext<AppContex>();
+  return språk;
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,6 +1,7 @@
 import { cssBundleHref } from '@remix-run/css-bundle';
 import designsystemStyles from '@navikt/ds-css/dist/index.css';
 import type { LinksFunction, LoaderFunction } from '@remix-run/node';
+import { AppContex, LocaleType } from './typer/sanity/sanity';
 import {
   Links,
   LiveReload,
@@ -9,8 +10,10 @@ import {
   Scripts,
   ScrollRestoration,
   useLoaderData,
+  useOutletContext,
 } from '@remix-run/react';
 import { hentDataFraSanity } from './utils/sanityLoader';
+import { useState } from 'react';
 
 export const links: LinksFunction = () => [
   { rel: 'stylesheet', href: designsystemStyles },
@@ -23,7 +26,8 @@ export const loader: LoaderFunction = async () => {
 
 export default function App() {
   const data = useLoaderData<typeof loader>();
-
+  const [spraak, settSpraak] = useState<LocaleType>(LocaleType.nb);
+  console.log(spraak);
   return (
     <html lang="en">
       <head>
@@ -33,11 +37,18 @@ export default function App() {
         <Links />
       </head>
       <body>
-        <Outlet context={data} />
+        <Outlet
+          context={{ sanityTekster: data, spraak: [spraak, settSpraak] }}
+        />
         <ScrollRestoration />
         <Scripts />
         <LiveReload />
       </body>
     </html>
   );
+}
+
+export function useSpraak() {
+  const { spraak } = useOutletContext<AppContex>();
+  return spraak;
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -29,7 +29,7 @@ export default function App() {
   const [språk, settSpråk] = useState<LocaleType>(LocaleType.nb);
 
   return (
-    <html lang="en">
+    <html lang={språk}>
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -37,7 +37,9 @@ export default function App() {
         <Links />
       </head>
       <body>
-        <Outlet context={{ sanityTekster: data, språk: [språk, settSpråk] }} />
+        <Outlet
+          context={{ sanityTekster: data, språkContext: [språk, settSpråk] }}
+        />
         <ScrollRestoration />
         <Scripts />
         <LiveReload />
@@ -47,6 +49,6 @@ export default function App() {
 }
 
 export function useSpråk() {
-  const { språk } = useOutletContext<AppContex>();
-  return språk;
+  const { språkContext } = useOutletContext<AppContex>();
+  return språkContext;
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,7 +1,7 @@
 import { cssBundleHref } from '@remix-run/css-bundle';
 import designsystemStyles from '@navikt/ds-css/dist/index.css';
 import type { LinksFunction, LoaderFunction } from '@remix-run/node';
-import { AppContex, LocaleType } from './typer/sanity/sanity';
+import { LocaleType } from './typer/sanity/sanity';
 import {
   Links,
   LiveReload,
@@ -14,6 +14,7 @@ import {
 } from '@remix-run/react';
 import { hentDataFraSanity } from './utils/sanityLoader';
 import { useState } from 'react';
+import { AppContex } from './typer/context';
 
 export const links: LinksFunction = () => [
   { rel: 'stylesheet', href: designsystemStyles },

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -2,11 +2,11 @@ import type { V2_MetaFunction } from '@remix-run/node';
 import css from './_index.module.css';
 import Spinner from '~/komponenter/Spinner';
 import VeilederHilsen from '../komponenter/veilederhilsen/veilederhilsen';
-import { ESanitySteg, LocaleType } from '~/typer/sanity/sanity';
+import { ESanitySteg } from '~/typer/sanity/sanity';
 import TekstBlokk from '~/komponenter/tekstBlokk/tekstBlokk';
 import { TypografiTyper } from '~/typer/typografi';
 import { useTekster } from '~/utils/sanityLoader';
-import { useSpraak } from '~/root';
+import { Språkvelger } from '~/komponenter/språkvelger/språkvelger';
 
 export const meta: V2_MetaFunction = () => {
   return [
@@ -21,9 +21,6 @@ export const meta: V2_MetaFunction = () => {
 
 export default function Index() {
   const tekster = useTekster(ESanitySteg.FORSIDE);
-  const [spraak, settSpraak] = useSpraak();
-  settSpraak(LocaleType.en);
-  console.log(spraak);
 
   return (
     <div className={`${css.sentrerTekst} ${css.fyllSide}`}>
@@ -36,6 +33,7 @@ export default function Index() {
               tekstblokk={tekster.tittel}
               typografi={TypografiTyper.StegHeadingH1}
             />
+            <Språkvelger />
             <VeilederHilsen innhold={tekster.veilederhilsenInnhold} />
             <div className={`${css.personvernerklaeringLink}`}>
               <TekstBlokk

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -6,8 +6,8 @@ import { ESanitySteg } from '~/typer/sanity/sanity';
 import TekstBlokk from '~/komponenter/tekstBlokk/tekstBlokk';
 import { TypografiTyper } from '~/typer/typografi';
 import { useTekster } from '~/utils/sanityLoader';
-import { Språkvelger } from '~/komponenter/språkvelger/språkvelger';
 import SamtykkePanel from '~/komponenter/SamtykkePanel';
+import { Språkvelger } from '~/komponenter/språkvelger/språkvelger';
 
 export const meta: V2_MetaFunction = () => {
   return [

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,12 +1,12 @@
 import type { V2_MetaFunction } from '@remix-run/node';
 import css from './_index.module.css';
-import React from 'react';
 import Spinner from '~/komponenter/Spinner';
 import VeilederHilsen from '../komponenter/veilederhilsen/veilederhilsen';
-import { ESanitySteg } from '~/typer/sanity/sanity';
+import { ESanitySteg, LocaleType } from '~/typer/sanity/sanity';
 import TekstBlokk from '~/komponenter/tekstBlokk/tekstBlokk';
 import { TypografiTyper } from '~/typer/typografi';
 import { useTekster } from '~/utils/sanityLoader';
+import { useSpraak } from '~/root';
 
 export const meta: V2_MetaFunction = () => {
   return [
@@ -21,6 +21,9 @@ export const meta: V2_MetaFunction = () => {
 
 export default function Index() {
   const tekster = useTekster(ESanitySteg.FORSIDE);
+  const [spraak, settSpraak] = useSpraak();
+  settSpraak(LocaleType.en);
+  console.log(spraak);
 
   return (
     <div className={`${css.sentrerTekst} ${css.fyllSide}`}>

--- a/app/typer/context.ts
+++ b/app/typer/context.ts
@@ -1,0 +1,7 @@
+import { Dispatch, SetStateAction } from 'react';
+import { ITekstinnhold, LocaleType } from './sanity/sanity';
+
+export interface AppContex {
+  sanityTekster: ITekstinnhold;
+  språkContext: [LocaleType, Dispatch<SetStateAction<LocaleType>>];
+}

--- a/app/typer/sanity/sanity.ts
+++ b/app/typer/sanity/sanity.ts
@@ -32,7 +32,7 @@ export interface ITekstinnhold {
 
 export interface AppContex {
   sanityTekster: ITekstinnhold;
-  språk: [LocaleType, React.Dispatch<React.SetStateAction<LocaleType>>];
+  språkContext: [LocaleType, React.Dispatch<React.SetStateAction<LocaleType>>];
 }
 
 export enum ESanityFlettefeltverdi {

--- a/app/typer/sanity/sanity.ts
+++ b/app/typer/sanity/sanity.ts
@@ -32,5 +32,5 @@ export interface ITekstinnhold {
 
 export interface AppContex {
   sanityTekster: ITekstinnhold;
-  spraak: [LocaleType, React.Dispatch<React.SetStateAction<LocaleType>>];
+  språk: [LocaleType, React.Dispatch<React.SetStateAction<LocaleType>>];
 }

--- a/app/typer/sanity/sanity.ts
+++ b/app/typer/sanity/sanity.ts
@@ -29,3 +29,8 @@ export type IForsideTekstinnhold = Record<string, SanityDokument>;
 export interface ITekstinnhold {
   [ESanitySteg.FORSIDE]: IForsideTekstinnhold;
 }
+
+export interface AppContex {
+  sanityTekster: ITekstinnhold;
+  spraak: [LocaleType, React.Dispatch<React.SetStateAction<LocaleType>>];
+}

--- a/app/typer/sanity/sanity.ts
+++ b/app/typer/sanity/sanity.ts
@@ -30,11 +30,6 @@ export interface ITekstinnhold {
   [ESanitySteg.FORSIDE]: IForsideTekstinnhold;
 }
 
-export interface AppContex {
-  sanityTekster: ITekstinnhold;
-  språkContext: [LocaleType, React.Dispatch<React.SetStateAction<LocaleType>>];
-}
-
 export enum ESanityFlettefeltverdi {
   SØKER_NAVN = 'SØKER_NAVN',
 }

--- a/app/utils/sanityLoader.ts
+++ b/app/utils/sanityLoader.ts
@@ -1,8 +1,8 @@
 import { useOutletContext } from '@remix-run/react';
 import { createClient } from '@sanity/client';
+import { AppContex } from '~/typer/context';
 
 import {
-  AppContex,
   ESanitySteg,
   ITekstinnhold,
   SanityDokument,

--- a/app/utils/sanityLoader.ts
+++ b/app/utils/sanityLoader.ts
@@ -1,6 +1,8 @@
 import { useOutletContext } from '@remix-run/react';
 import { createClient } from '@sanity/client';
+
 import {
+  AppContex,
   ESanitySteg,
   ITekstinnhold,
   SanityDokument,
@@ -36,6 +38,6 @@ const strukturerInnholdForSteg = (
     }, {});
 
 export function useTekster(steg: ESanitySteg) {
-  const tekster = useOutletContext<ITekstinnhold>();
-  return tekster[steg];
+  const { sanityTekster } = useOutletContext<AppContex>();
+  return sanityTekster[steg];
 }


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
Legger inn språkvelger for å la søkeren bytte mellom språk slik at teksten vise på de mulige språkene. 

[Lenke til trello kort](https://trello.com/c/xT6909rM/15-legge-inn-spr%C3%A5kvelger)

### Hvordan er det løst? 🧠
Språk er lagt til i contextet sammen med dataen fra sanity slik at man kan hente ut den staten man trenger med en egen function for `useSpråk`. I tillegg er det laget et eget komponent for språkvelger som bruker `useSpråk` for å sette språket basert på hva som er valgt i språkvelgeren. 

Bilde av resultatet:
<img width="221" alt="Screenshot 2023-06-21 at 12 21 04" src="https://github.com/bekk/nav-familie-endringsmelding/assets/54811230/facce6f5-0d2f-4d59-80fa-9d706e654c99">