### PR TITLE
Byttet ut link fra en <a> til <link > i teksblokk

### DIFF
--- a/app/komponenter/tekstBlokk/tekstBlokk.tsx
+++ b/app/komponenter/tekstBlokk/tekstBlokk.tsx
@@ -4,6 +4,7 @@ import { PortableText } from '@portabletext/react';
 import { TypografiWrapper } from '~/utils/typografiWrapper';
 import { LocaleType, SanityDokument } from '~/typer/sanity/sanity';
 import { flettefeltTilTekst } from '~/utils/fletteTilTekst';
+import { Link } from '@navikt/ds-react';
 
 interface Props {
   tekstblokk: SanityDokument | undefined;
@@ -46,13 +47,13 @@ const TekstBlokk: React.FC<Props> = ({ tekstblokk, typografi }: Props) => {
           },
           link: props => {
             return (
-              <a
+              <Link
                 target={props.value.blank ? '_blank' : '_self'}
                 href={encodeURI(props.value.href)}
                 rel="noreferrer"
               >
                 {props.text}
-              </a>
+              </Link>
             );
           },
         },


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
vi brukte a men ønsker å bruke aksel sin link

[Lenke til trello kort](https://trello.com/c/IMhLNgh1/56-bruke-nav-sin-link-og-ikke-a)

### Hvordan er det løst? 🧠
Endret fra a til link
