### PR TITLE
Fikse font bug

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -16,7 +16,17 @@ import { hentSøker } from './utils/hentFraApi';
 import { useState } from 'react';
 
 export const links: LinksFunction = () => [
-  { rel: 'preconnect', href: designsystemStyles },
+  {
+    rel: 'stylesheet',
+    href: designsystemStyles,
+  },
+  {
+    rel: 'preload',
+    href: 'https://cdn.nav.no/aksel/fonts/SourceSans3-normal.woff2',
+    as: 'font',
+    type: 'font/woff2',
+    crossOrigin: 'anonymous',
+  },
   ...(cssBundleHref ? [{ rel: 'stylesheet', href: cssBundleHref }] : []),
 ];
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -16,7 +16,7 @@ import { hentSøker } from './utils/hentFraApi';
 import { useState } from 'react';
 
 export const links: LinksFunction = () => [
-  { rel: 'stylesheet', href: designsystemStyles },
+  { rel: 'preconnect', href: designsystemStyles },
   ...(cssBundleHref ? [{ rel: 'stylesheet', href: cssBundleHref }] : []),
 ];
 


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

Skal fikse bug der fonten blir hentet etter klienten vises, som gjør at fallback-font vises i et øyeblikk.
[Lenke til trello kort](https://trello.com/c/2AvnJfcj/57-bug-fonter-laster-rart)

### Hvordan er det løst? 🧠
La til en link i `links` I `root.tsx`. Hentet denne fra [denne siden i Aksel](https://aksel.nav.no/grunnleggende/kode/migrering#h76f47744d112). Måtte legge denne til etter `designsystemStyles`, ettersom å endre på denne fjernet all annen styling fra Nav. 