### PR TITLE
Endre useTekster og bruken av den

### DIFF
--- a/app/hooks/contextHooks.ts
+++ b/app/hooks/contextHooks.ts
@@ -1,9 +1,10 @@
 import { useOutletContext } from '@remix-run/react';
 import { AppContext } from '~/typer/context';
+import { ESanitySteg } from '~/typer/sanity/sanity';
 
-export function useTekster() {
+export function useTekster<Steg extends ESanitySteg>(steg: Steg) {
   const { sanityTekster } = useOutletContext<AppContext>();
-  return sanityTekster;
+  return sanityTekster[steg];
 }
 
 export function useSpråk() {

--- a/app/komponenter/banner/Banner.tsx
+++ b/app/komponenter/banner/Banner.tsx
@@ -5,8 +5,7 @@ import { TypografiTyper } from '~/typer/typografi';
 import { useTekster } from '~/hooks/contextHooks';
 
 const Banner: React.FC = () => {
-  const sanityTekster = useTekster();
-  const { bannerTekst } = sanityTekster[ESanitySteg.FELLES];
+  const { bannerTekst } = useTekster(ESanitySteg.FELLES);
 
   return (
     <section className={`${css.bannerStil}`}>

--- a/app/komponenter/samtykkepanel/SamtykkePanel.tsx
+++ b/app/komponenter/samtykkepanel/SamtykkePanel.tsx
@@ -3,27 +3,20 @@ import { useState } from 'react';
 import TekstBlokk from '../tekstblokk/TekstBlokk';
 import css from './samtykkepanel.module.css';
 import { TypografiTyper } from '~/typer/typografi';
-import { IForsideTekstinnhold } from '~/typer/sanity/sanityForside';
+import { useTekster } from '~/hooks/contextHooks';
+import { ESanitySteg } from '~/typer/sanity/sanity';
 
 interface Props {
-  tekster: IForsideTekstinnhold;
   håndterSamtykkeEndring: (bekreftet: boolean) => void;
   feilmeldingAktivert: boolean;
 }
 
 const SamtykkePanel: React.FC<Props> = ({
-  tekster,
   håndterSamtykkeEndring,
   feilmeldingAktivert,
 }: Props) => {
+  const tekster = useTekster(ESanitySteg.FORSIDE);
   const [erSamtykkeBekreftet, settErSamtykkeBekreftet] = useState(false);
-
-  const {
-    samtykkePanelTittel,
-    samtykkePanelSamtykke,
-    samtykkePanelFeilmelding,
-    samtykkePanelMelding,
-  } = tekster;
 
   const vedSamtykkeEndring = (bekreftet: boolean) => {
     settErSamtykkeBekreftet(bekreftet);
@@ -32,10 +25,10 @@ const SamtykkePanel: React.FC<Props> = ({
 
   return (
     <div className={`${css.samtykkePanelOmråde}`}>
-      <TekstBlokk tekstblokk={samtykkePanelTittel} />
+      <TekstBlokk tekstblokk={tekster.samtykkePanelTittel} />
       <ConfirmationPanel
         checked={erSamtykkeBekreftet}
-        label={<TekstBlokk tekstblokk={samtykkePanelSamtykke} />}
+        label={<TekstBlokk tekstblokk={tekster.samtykkePanelSamtykke} />}
         onChange={() => {
           vedSamtykkeEndring(!erSamtykkeBekreftet);
         }}
@@ -43,13 +36,13 @@ const SamtykkePanel: React.FC<Props> = ({
           !erSamtykkeBekreftet &&
           feilmeldingAktivert && (
             <TekstBlokk
-              tekstblokk={samtykkePanelFeilmelding}
+              tekstblokk={tekster.samtykkePanelFeilmelding}
               typografi={TypografiTyper.BodyShort}
             /> //denne gir feilmelding fordi den ikke er en ren String ("kan ikke være i <p>"). Visuelt fungerer den.
           )
         }
       >
-        <TekstBlokk tekstblokk={samtykkePanelMelding} />
+        <TekstBlokk tekstblokk={tekster.samtykkePanelMelding} />
       </ConfirmationPanel>
     </div>
   );

--- a/app/komponenter/veilederhilsen/VeilederHilsen.tsx
+++ b/app/komponenter/veilederhilsen/VeilederHilsen.tsx
@@ -5,23 +5,23 @@ import { AppContext } from '~/typer/context';
 import { useOutletContext } from '@remix-run/react';
 import { hentSøkerFornavn } from '~/utils/hentSøkerData';
 import TekstBlokk from '../tekstblokk/TekstBlokk';
-import { IForsideTekstinnhold } from '~/typer/sanity/sanityForside';
+import { ESanitySteg } from '~/typer/sanity/sanity';
+import { useTekster } from '~/hooks/contextHooks';
 
-interface Props {
-  tekster: IForsideTekstinnhold;
-}
-
-const VeilederHilsen: React.FC<Props> = ({ tekster }: Props) => {
+const VeilederHilsen: React.FC = () => {
   const { søker } = useOutletContext<AppContext>();
+  const { brukerHilsen, veilederhilsenInnhold } = useTekster(
+    ESanitySteg.FORSIDE,
+  );
 
   return (
     <GuidePanel poster className={`${css.poster}`}>
       <TekstBlokk
-        tekstblokk={tekster.brukerHilsen}
+        tekstblokk={brukerHilsen}
         typografi={TypografiTyper.StegHeadingH2}
         flettefelter={{ søkerNavn: hentSøkerFornavn(søker) }}
       />
-      <TekstBlokk tekstblokk={tekster.veilederhilsenInnhold} />
+      <TekstBlokk tekstblokk={veilederhilsenInnhold} />
     </GuidePanel>
   );
 };

--- a/app/komponenter/veiledning/Veiledning.tsx
+++ b/app/komponenter/veiledning/Veiledning.tsx
@@ -1,16 +1,18 @@
 import { GuidePanel } from '@navikt/ds-react';
 import TekstBlokk from '../tekstblokk/TekstBlokk';
-import { SanityDokument } from '~/typer/sanity/sanity';
+import { ESanitySteg } from '~/typer/sanity/sanity';
 import { TypografiTyper } from '~/typer/typografi';
+import { useTekster } from '~/hooks/contextHooks';
 
-interface Props {
-  hilsen: SanityDokument;
-}
+const Veiledning: React.FC = () => {
+  const { veilederInnhold } = useTekster(ESanitySteg.SEND_ENDRINGER);
 
-const Veiledning: React.FC<Props> = ({ hilsen }: Props) => {
   return (
     <GuidePanel>
-      <TekstBlokk tekstblokk={hilsen} typografi={TypografiTyper.BodyShort} />
+      <TekstBlokk
+        tekstblokk={veilederInnhold}
+        typografi={TypografiTyper.BodyShort}
+      />
     </GuidePanel>
   );
 };

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -26,8 +26,8 @@ export const meta: V2_MetaFunction = () => {
 };
 
 export default function Index() {
-  const sanityTekster = useTekster();
-  const tekster = sanityTekster[ESanitySteg.FORSIDE];
+  const tekster = useTekster(ESanitySteg.FORSIDE);
+
   const [erSamtykkeBekreftet, settErSamtykkeBekreftet] = useState(false);
   const [erFeilmeldingAktivert, settErFeilmeldingAktivert] = useState(false);
 
@@ -56,9 +56,8 @@ export default function Index() {
             />
           </div>
           <Språkvelger />
-          <VeilederHilsen tekster={tekster} />
+          <VeilederHilsen />
           <SamtykkePanel
-            tekster={tekster}
             håndterSamtykkeEndring={håndterSamtykkeEndring}
             feilmeldingAktivert={erFeilmeldingAktivert}
           />

--- a/app/routes/send-endringsmelding.tsx
+++ b/app/routes/send-endringsmelding.tsx
@@ -13,19 +13,8 @@ import Veiledning from '~/komponenter/veiledning/Veiledning';
 import css from './send-endringsmelding.module.css';
 
 export default function SendEndringsmelding() {
-  const sanityTekster = useTekster();
-  const {
-    overskrift,
-    veilederInnhold,
-    fritekstfeltTittel,
-    fritekstfeltBeskrivelse,
-    fritekstfeltFeilmeldingManglerTekst,
-    fritekstfeltFeilmeldingSpesialTegn,
-    fritekstfeltFeilmeldingMinTegn,
-  } = sanityTekster[ESanitySteg.SEND_ENDRINGER];
-
-  const { knappTilbake, knappSendEndringer } =
-    sanityTekster[ESanitySteg.FELLES];
+  const tekster = useTekster(ESanitySteg.SEND_ENDRINGER);
+  const teksterFelles = useTekster(ESanitySteg.FELLES);
 
   const navigate = useNavigate();
   const [språk] = useSpråk();
@@ -67,11 +56,15 @@ export default function SendEndringsmelding() {
 
   const utledFeilmelding = () => {
     if (manglerTekst) {
-      return <TekstBlokk tekstblokk={fritekstfeltFeilmeldingManglerTekst} />;
+      return (
+        <TekstBlokk tekstblokk={tekster.fritekstfeltFeilmeldingManglerTekst} />
+      );
     } else if (brukerSpesialtegn) {
-      return <TekstBlokk tekstblokk={fritekstfeltFeilmeldingSpesialTegn} />;
+      return (
+        <TekstBlokk tekstblokk={tekster.fritekstfeltFeilmeldingSpesialTegn} />
+      );
     } else if (!minimumTegnOppfylt) {
-      return <TekstBlokk tekstblokk={fritekstfeltFeilmeldingMinTegn} />;
+      return <TekstBlokk tekstblokk={tekster.fritekstfeltFeilmeldingMinTegn} />;
     }
   };
 
@@ -88,14 +81,16 @@ export default function SendEndringsmelding() {
       <StegIndikator nåværendeSteg={1} />
 
       <TekstBlokk
-        tekstblokk={overskrift}
+        tekstblokk={tekster.overskrift}
         typografi={TypografiTyper.StegHeadingH1}
       />
-      <Veiledning hilsen={veilederInnhold} />
+      <Veiledning />
 
       <Textarea
-        label={<TekstBlokk tekstblokk={fritekstfeltTittel} />}
-        description={<TekstBlokk tekstblokk={fritekstfeltBeskrivelse} />}
+        label={<TekstBlokk tekstblokk={tekster.fritekstfeltTittel} />}
+        description={
+          <TekstBlokk tekstblokk={tekster.fritekstfeltBeskrivelse} />
+        }
         maxLength={MAKS_INPUT_LENGDE}
         className={`${cssFritekst.fritekstfelt}`}
         i18n={i18nInnhold}
@@ -109,7 +104,7 @@ export default function SendEndringsmelding() {
           variant={'secondary'}
           onClick={() => navigate(hentPathForSteg(ESanitySteg.FORSIDE))}
         >
-          <TekstBlokk tekstblokk={knappTilbake} />
+          <TekstBlokk tekstblokk={teksterFelles.knappTilbake} />
         </Button>
         <Button
           variant={tekstInputOK ? 'primary' : 'secondary'}
@@ -118,7 +113,7 @@ export default function SendEndringsmelding() {
             tekstInputOK && console.log('går til neste side');
           }}
         >
-          <TekstBlokk tekstblokk={knappSendEndringer} />
+          <TekstBlokk tekstblokk={teksterFelles.knappSendEndringer} />
         </Button>
       </div>
     </HovedInnhold>


### PR DESCRIPTION

### Hvorfor er dette nødvendig? ✨
For å forenkle hvordan vi henter tekster fra Sanity skal man nå sende inn steget man vil ha tekster til i useTekster-hooken for å så bare få tilbake de tekstene som er relevante for den siden. I tillegg blir denne hooken nå brukt i de komponentene der vi henter tekster fra Sanity slik at disse ikke behøver å bli propet til komponentet. 

### Hvordan er det løst? 🧠
`useTekster` tar inn steg slik at den barer returnerer tekstene som hører til dette steget og disse samsvarer med interfacet som er definert for det gitte steget i `ITekstinnhold`. 
I tillegg blir hooken useTekster brukt i både `VeilederHilsen`, `Veileder `og `Samtykkepanel` for å hente tekstene som blir brukt her. Disse ble tidligere sendt som props. 