### PR TITLE
Legg token i cookie storage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,6 @@ jobs:
           field: app
 
       - name: 🚀 Deploy Production
-        if: ${{ github.ref == 'refs/heads/main' }}
         uses: superfly/flyctl-actions@1.4
         with:
           args: deploy --remote-only --build-arg NPM_AUTH_TOKEN=${{ secrets.NPM_AUTH_TOKEN }} --build-arg COMMIT_SHA=${{ github.sha }} --app ${{ steps.app_name.outputs.value }}

--- a/app/server/authorization.ts
+++ b/app/server/authorization.ts
@@ -21,7 +21,7 @@ export const fetchWithToken = async (
 };
 
 const prepareSecuredRequest = async (session: Session) => {
-  const token = (await hentApiToken(session)) ?? '';
+  const token = (await session.get(API_TOKEN_NAME)) ?? '';
 
   // TODO: TokenX-exchange i NAV-miljø
   return {
@@ -40,10 +40,6 @@ async function hentCookieFraBackend() {
 
 export async function loggInn(session: Session) {
   session.set(API_TOKEN_NAME, (await hentCookieFraBackend()).value);
-}
-
-async function hentApiToken(session: Session) {
-  return session.get(API_TOKEN_NAME);
 }
 
 const hentApiUrl = () => {

--- a/app/server/authorization.ts
+++ b/app/server/authorization.ts
@@ -1,12 +1,14 @@
-import cookie from 'cookie';
+import { EMiljø } from '~/typer/miljø';
+import { Session } from '@remix-run/node';
+import { API_TOKEN_NAME } from '~/sessions';
 
 export const fetchWithToken = async (
-  remixRequest: Request,
+  session: Session,
   url: string,
   requestInfo?: Request,
 ): Promise<Response> => {
   const headersFromRequest = requestInfo?.headers || {};
-  const token = await prepareSecuredRequest(remixRequest);
+  const token = await prepareSecuredRequest(session);
   const headersWithToken = new Headers({
     ...headersFromRequest,
     authorization: token.authorization,
@@ -18,16 +20,43 @@ export const fetchWithToken = async (
   });
 };
 
-const utledToken = (req: Request) => {
-  const cookies = req.headers.get('Cookie');
-  const cookiesFromHeader = cookies ? cookie.parse(cookies) : {};
-  return cookiesFromHeader['localhost-idtoken'];
-};
+const prepareSecuredRequest = async (session: Session) => {
+  const token = (await hentApiToken(session)) ?? "";
 
-const prepareSecuredRequest = async (req: Request) => {
-  const token = utledToken(req);
   // TODO: TokenX-exchange i NAV-miljø
   return {
     authorization: `Bearer ${token}`,
   };
+};
+
+async function hentCookieFraBackend() {
+  const apiUrl = hentApiUrl();
+  const url =
+    apiUrl + '/local/cookie?issuerId=tokenx&audience=familie-endringsmelding';
+
+  console.log("url", url)
+
+  const cookieResponse = await fetch(url);
+  const newVar = await cookieResponse.json();
+
+  console.log(newVar)
+
+  return newVar;
+}
+
+export async function loggInn(session: Session) {
+  session.set(API_TOKEN_NAME, (await hentCookieFraBackend()).value);
+}
+
+async function hentApiToken(session: Session) {
+  return session.get(API_TOKEN_NAME);
+}
+
+const hentApiUrl = () => {
+  switch (process.env.ENV) {
+    case EMiljø.PRODUKSJON:
+      return 'https://nav-familie-endringsmelding-api.fly.dev';
+    case EMiljø.LOKAL:
+      return 'http://localhost:8099';
+  }
 };

--- a/app/server/authorization.ts
+++ b/app/server/authorization.ts
@@ -21,7 +21,7 @@ export const fetchWithToken = async (
 };
 
 const prepareSecuredRequest = async (session: Session) => {
-  const token = (await hentApiToken(session)) ?? "";
+  const token = (await hentApiToken(session)) ?? '';
 
   // TODO: TokenX-exchange i NAV-miljø
   return {
@@ -34,14 +34,8 @@ async function hentCookieFraBackend() {
   const url =
     apiUrl + '/local/cookie?issuerId=tokenx&audience=familie-endringsmelding';
 
-  console.log("url", url)
-
   const cookieResponse = await fetch(url);
-  const newVar = await cookieResponse.json();
-
-  console.log(newVar)
-
-  return newVar;
+  return await cookieResponse.json();
 }
 
 export async function loggInn(session: Session) {
@@ -54,9 +48,10 @@ async function hentApiToken(session: Session) {
 
 const hentApiUrl = () => {
   switch (process.env.ENV) {
-    case EMiljø.PRODUKSJON:
-      return 'https://nav-familie-endringsmelding-api.fly.dev';
     case EMiljø.LOKAL:
       return 'http://localhost:8099';
+    case EMiljø.PRODUKSJON:
+    default:
+      return 'https://nav-familie-endringsmelding-api.fly.dev';
   }
 };

--- a/app/sessions.ts
+++ b/app/sessions.ts
@@ -1,0 +1,21 @@
+// app/sessions.ts
+import { createCookieSessionStorage } from '@remix-run/node';
+
+export const API_TOKEN_NAME = 'token';
+type SessionData = {
+  token: any;
+};
+
+type SessionFlashData = {
+  error: string;
+};
+
+const { getSession, commitSession, destroySession } =
+  createCookieSessionStorage<SessionData, SessionFlashData>({
+    cookie: {
+      name: 'api-session',
+      maxAge: 3600,
+    },
+  });
+
+export { getSession, commitSession, destroySession };

--- a/app/sessions.ts
+++ b/app/sessions.ts
@@ -2,13 +2,14 @@
 import { createCookieSessionStorage } from '@remix-run/node';
 
 export const API_TOKEN_NAME = 'token';
-type SessionData = {
-  token: any;
-};
 
-type SessionFlashData = {
-  error: string;
-};
+interface SessionData {
+    token: string;
+}
+
+interface SessionFlashData {
+    error: string;
+}
 
 const { getSession, commitSession, destroySession } =
   createCookieSessionStorage<SessionData, SessionFlashData>({

--- a/app/utils/hentFraApi.ts
+++ b/app/utils/hentFraApi.ts
@@ -2,18 +2,19 @@ import søkerMock from '~/mock/søkerMock';
 import { fetchWithToken } from '~/server/authorization';
 import { EMiljø } from '~/typer/miljø';
 import { ISøker } from '~/typer/søker';
+import {Session} from "@remix-run/node";
 
 const STI: string = '/api/oppslag/soker';
 const LOKAL_URL_BACKEND: string = 'http://localhost:8099' + STI;
 const API_URL_BACKEND: string =
   'https://nav-familie-endringsmelding-api.fly.dev/' + STI;
 
-export const hentSøker = async (request: Request): Promise<ISøker> => {
+export const hentSøker = async (session: Session): Promise<ISøker> => {
   switch (process.env.ENV) {
     case EMiljø.LOKAL:
-      return (await fetchWithToken(request, LOKAL_URL_BACKEND)).json();
+      return (await fetchWithToken(session, LOKAL_URL_BACKEND)).json();
     case EMiljø.PRODUKSJON:
-      return (await fetchWithToken(request, API_URL_BACKEND)).json();
+      return (await fetchWithToken(session, API_URL_BACKEND)).json();
     default:
       return Promise.resolve(søkerMock);
   }

--- a/app/utils/hentFraApi.ts
+++ b/app/utils/hentFraApi.ts
@@ -1,8 +1,7 @@
-import søkerMock from '~/mock/søkerMock';
 import { fetchWithToken } from '~/server/authorization';
 import { EMiljø } from '~/typer/miljø';
 import { ISøker } from '~/typer/søker';
-import {Session} from "@remix-run/node";
+import { Session } from '@remix-run/node';
 
 const STI: string = '/api/oppslag/soker';
 const LOKAL_URL_BACKEND: string = 'http://localhost:8099' + STI;
@@ -14,8 +13,7 @@ export const hentSøker = async (session: Session): Promise<ISøker> => {
     case EMiljø.LOKAL:
       return (await fetchWithToken(session, LOKAL_URL_BACKEND)).json();
     case EMiljø.PRODUKSJON:
-      return (await fetchWithToken(session, API_URL_BACKEND)).json();
     default:
-      return Promise.resolve(søkerMock);
+      return (await fetchWithToken(session, API_URL_BACKEND)).json();
   }
 };

--- a/app/utils/hentFraApi.ts
+++ b/app/utils/hentFraApi.ts
@@ -7,7 +7,7 @@ import {Session} from "@remix-run/node";
 const STI: string = '/api/oppslag/soker';
 const LOKAL_URL_BACKEND: string = 'http://localhost:8099' + STI;
 const API_URL_BACKEND: string =
-  'https://nav-familie-endringsmelding-api.fly.dev/' + STI;
+  'https://nav-familie-endringsmelding-api.fly.dev' + STI;
 
 export const hentSøker = async (session: Session): Promise<ISøker> => {
   switch (process.env.ENV) {


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
Det er ikke mulig å sette cookie automatisk slik som vi har prøvd å gjøre siden `https://nav-familie-endringsmelding.fly.dev/` og `https://nav-familie-endringsmelding-api.fly.dev/` er forskjellige domener. Det er heller ikke mulig å sette cookien for `*.fly.dev` siden `fly.dev` er et public domene. 

### Hvordan er det løst? 🧠
Lagrer tokenet som vi henter fra backend i en [session storage](https://remix.run/docs/en/main/utils/sessions#createcookiesessionstorage). Mulig at dette kunne vært løst på en enklere måte, som å sette cookien vi får fra backend direkte