### PR TITLE
Hent tekst til startknapp på forside fra sanity

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -27,6 +27,7 @@ export const meta: V2_MetaFunction = () => {
 
 export default function Index() {
   const tekster = useTekster(ESanitySteg.FORSIDE);
+  const { knappStart } = useTekster(ESanitySteg.FELLES);
 
   const [erSamtykkeBekreftet, settErSamtykkeBekreftet] = useState(false);
   const [erFeilmeldingAktivert, settErFeilmeldingAktivert] = useState(false);
@@ -69,7 +70,7 @@ export default function Index() {
                 : håndterKnappeTrykk
             }
           >
-            Start
+            <TekstBlokk tekstblokk={knappStart} />
           </Button>
           <TekstBlokk tekstblokk={tekster.linkTilPersonvernerklaering} />
         </>

--- a/app/typer/sanity/sanityFelles.ts
+++ b/app/typer/sanity/sanityFelles.ts
@@ -4,6 +4,7 @@ export enum EApiKeysFelles {
   KNAPP_TILBAKE = 'knappTilbake',
   KNAPP_SEND_ENDRINGER = 'knappSendEndringer',
   BANNER = 'bannerTekst',
+  KNAPP_START = 'knappStart',
 }
 
 export type IFellesTekstinnhold = Record<EApiKeysFelles, SanityDokument>;


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

Teksten er hentet fra sanity, så den enkelt kan endres
[Lenke til trello kort](https://trello.com/c/Wj8hMNq1/75-hente-tekst-på-knapper-fra-sanity)

### Hvordan er det løst? 🧠
Jeg endret fra "start" i knappen til å hente tekst fra sanity, ved bruk av tekstblokk
