### PR TITLE
Behold bekreftet samtykke state

### DIFF
--- a/app/context/InnsendingContext.tsx
+++ b/app/context/InnsendingContext.tsx
@@ -1,7 +1,0 @@
-import { useOutletContext } from '@remix-run/react';
-import { AppContext } from '~/typer/context';
-
-export function useBekreftetSamtykke() {
-  const { erSamtykkeBekreftetContext } = useOutletContext<AppContext>();
-  return erSamtykkeBekreftetContext;
-}

--- a/app/context/InnsendingContext.tsx
+++ b/app/context/InnsendingContext.tsx
@@ -1,0 +1,7 @@
+import { useOutletContext } from '@remix-run/react';
+import { AppContext } from '~/typer/context';
+
+export function useBekreftetSamtykke() {
+  const { erSamtykkeBekreftetContext } = useOutletContext<AppContext>();
+  return erSamtykkeBekreftetContext;
+}

--- a/app/hooks/contextHooks.ts
+++ b/app/hooks/contextHooks.ts
@@ -11,3 +11,8 @@ export function useSpråk() {
   const { språkContext } = useOutletContext<AppContext>();
   return språkContext;
 }
+
+export function useBekreftetSamtykke() {
+  const { erSamtykkeBekreftetContext } = useOutletContext<AppContext>();
+  return erSamtykkeBekreftetContext;
+}

--- a/app/komponenter/samtykkepanel/SamtykkePanel.tsx
+++ b/app/komponenter/samtykkepanel/SamtykkePanel.tsx
@@ -6,7 +6,7 @@ import { useBekreftetSamtykke, useTekster } from '~/hooks/contextHooks';
 import { ESanitySteg } from '~/typer/sanity/sanity';
 
 interface Props {
-  håndterSamtykkeEndring: (bekreftet: boolean) => void;
+  håndterSamtykkeEndring: () => void;
   feilmeldingAktivert: boolean;
 }
 
@@ -19,7 +19,7 @@ const SamtykkePanel: React.FC<Props> = ({
 
   const vedSamtykkeEndring = (bekreftet: boolean) => {
     settErSamtykkeBekreftet(bekreftet);
-    håndterSamtykkeEndring(bekreftet);
+    håndterSamtykkeEndring();
   };
 
   return (

--- a/app/komponenter/samtykkepanel/SamtykkePanel.tsx
+++ b/app/komponenter/samtykkepanel/SamtykkePanel.tsx
@@ -1,10 +1,10 @@
 import { ConfirmationPanel } from '@navikt/ds-react';
-import { useState } from 'react';
 import TekstBlokk from '../tekstblokk/TekstBlokk';
 import css from './samtykkepanel.module.css';
 import { TypografiTyper } from '~/typer/typografi';
 import { useTekster } from '~/hooks/contextHooks';
 import { ESanitySteg } from '~/typer/sanity/sanity';
+import { useBekreftetSamtykke } from '~/context/InnsendingContext';
 
 interface Props {
   håndterSamtykkeEndring: (bekreftet: boolean) => void;
@@ -16,7 +16,7 @@ const SamtykkePanel: React.FC<Props> = ({
   feilmeldingAktivert,
 }: Props) => {
   const tekster = useTekster(ESanitySteg.FORSIDE);
-  const [erSamtykkeBekreftet, settErSamtykkeBekreftet] = useState(false);
+  const [erSamtykkeBekreftet, settErSamtykkeBekreftet] = useBekreftetSamtykke();
 
   const vedSamtykkeEndring = (bekreftet: boolean) => {
     settErSamtykkeBekreftet(bekreftet);

--- a/app/komponenter/samtykkepanel/SamtykkePanel.tsx
+++ b/app/komponenter/samtykkepanel/SamtykkePanel.tsx
@@ -2,9 +2,8 @@ import { ConfirmationPanel } from '@navikt/ds-react';
 import TekstBlokk from '../tekstblokk/TekstBlokk';
 import css from './samtykkepanel.module.css';
 import { TypografiTyper } from '~/typer/typografi';
-import { useTekster } from '~/hooks/contextHooks';
+import { useBekreftetSamtykke, useTekster } from '~/hooks/contextHooks';
 import { ESanitySteg } from '~/typer/sanity/sanity';
-import { useBekreftetSamtykke } from '~/context/InnsendingContext';
 
 interface Props {
   håndterSamtykkeEndring: (bekreftet: boolean) => void;

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -39,6 +39,7 @@ export const loader: LoaderFunction = async ({ request }: LoaderArgs) => {
 export default function App() {
   const { tekstData, søkerData } = useLoaderData<typeof loader>();
   const [språk, settSpråk] = useState<LocaleType>(LocaleType.nb);
+  const [erSamtykkeBekreftet, settErSamtykkeBekreftet] = useState(false);
 
   return (
     <Dokument språk={språk}>
@@ -48,6 +49,10 @@ export default function App() {
             sanityTekster: tekstData,
             språkContext: [språk, settSpråk],
             søker: søkerData,
+            erSamtykkeBekreftetContext: [
+              erSamtykkeBekreftet,
+              settErSamtykkeBekreftet,
+            ],
           }}
         />
         <ScrollRestoration />

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -28,15 +28,14 @@ export const meta: V2_MetaFunction = () => {
 export default function Index() {
   const tekster = useTekster(ESanitySteg.FORSIDE);
   const { knappStart } = useTekster(ESanitySteg.FELLES);
-  const [erSamtykkeBekreftet, settErSamtykkeBekreftet] = useBekreftetSamtykke();
+  const [erSamtykkeBekreftet] = useBekreftetSamtykke();
 
   const [erFeilmeldingAktivert, settErFeilmeldingAktivert] = useState(false);
 
   const navigate = useNavigate();
   const nestePath = hentPathForSteg(ESanitySteg.SEND_ENDRINGER);
 
-  const håndterSamtykkeEndring = (bekreftet: boolean) => {
-    settErSamtykkeBekreftet(bekreftet);
+  const håndterSamtykkeEndring = () => {
     settErFeilmeldingAktivert(false);
   };
 

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -8,7 +8,7 @@ import { TypografiTyper } from '~/typer/typografi';
 import { Språkvelger } from '~/komponenter/språkvelger/språkvelger';
 import HovedInnhold from '~/komponenter/hovedInnhold/HovedInnhold';
 import { useTekster } from '~/hooks/contextHooks';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@navikt/ds-react';
 import { useNavigate } from '@remix-run/react';
 import { hentPathForSteg } from '~/utils/hentPathForSteg';
@@ -44,10 +44,6 @@ export default function Index() {
   const håndterKnappeTrykk = () => {
     settErFeilmeldingAktivert(true);
   };
-
-  useEffect(() => {
-    settErSamtykkeBekreftet(erSamtykkeBekreftet);
-  }, [erSamtykkeBekreftet, settErSamtykkeBekreftet]);
 
   return (
     <HovedInnhold>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -8,11 +8,12 @@ import { TypografiTyper } from '~/typer/typografi';
 import { Språkvelger } from '~/komponenter/språkvelger/språkvelger';
 import HovedInnhold from '~/komponenter/hovedInnhold/HovedInnhold';
 import { useTekster } from '~/hooks/contextHooks';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@navikt/ds-react';
 import { useNavigate } from '@remix-run/react';
 import { hentPathForSteg } from '~/utils/hentPathForSteg';
 import SamtykkePanel from '~/komponenter/samtykkepanel/SamtykkePanel';
+import { useBekreftetSamtykke } from '~/context/InnsendingContext';
 
 export const meta: V2_MetaFunction = () => {
   return [
@@ -28,8 +29,8 @@ export const meta: V2_MetaFunction = () => {
 export default function Index() {
   const tekster = useTekster(ESanitySteg.FORSIDE);
   const { knappStart } = useTekster(ESanitySteg.FELLES);
+  const [erSamtykkeBekreftet, settErSamtykkeBekreftet] = useBekreftetSamtykke();
 
-  const [erSamtykkeBekreftet, settErSamtykkeBekreftet] = useState(false);
   const [erFeilmeldingAktivert, settErFeilmeldingAktivert] = useState(false);
 
   const navigate = useNavigate();
@@ -43,6 +44,10 @@ export default function Index() {
   const håndterKnappeTrykk = () => {
     settErFeilmeldingAktivert(true);
   };
+
+  useEffect(() => {
+    settErSamtykkeBekreftet(erSamtykkeBekreftet);
+  }, [erSamtykkeBekreftet, settErSamtykkeBekreftet]);
 
   return (
     <HovedInnhold>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -7,13 +7,12 @@ import TekstBlokk from '~/komponenter/tekstblokk/TekstBlokk';
 import { TypografiTyper } from '~/typer/typografi';
 import { Språkvelger } from '~/komponenter/språkvelger/språkvelger';
 import HovedInnhold from '~/komponenter/hovedInnhold/HovedInnhold';
-import { useTekster } from '~/hooks/contextHooks';
+import { useBekreftetSamtykke, useTekster } from '~/hooks/contextHooks';
 import { useState } from 'react';
 import { Button } from '@navikt/ds-react';
 import { useNavigate } from '@remix-run/react';
 import { hentPathForSteg } from '~/utils/hentPathForSteg';
 import SamtykkePanel from '~/komponenter/samtykkepanel/SamtykkePanel';
-import { useBekreftetSamtykke } from '~/context/InnsendingContext';
 
 export const meta: V2_MetaFunction = () => {
   return [

--- a/app/typer/context.ts
+++ b/app/typer/context.ts
@@ -6,4 +6,5 @@ export interface AppContext {
   sanityTekster: ITekstinnhold;
   språkContext: [LocaleType, Dispatch<SetStateAction<LocaleType>>];
   søker: ISøker;
+  erSamtykkeBekreftetContext: [boolean, Dispatch<SetStateAction<boolean>>];
 }


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
Hvis bekreftelsen er trykket godkjent på blir det borte hvis man går videre og tilbake igjen på nettsiden.

For å lage denne buggen måtte du:

1. Bekrefte samtykke
2. Gå til neste side
3. Gå tilbake 

Da skal samtykke ikkje være bekreftet men vi ønsker at den skal være bekreftet når du kommer tilbake. 

[Lenke til trello kort](https://trello.com/c/ccSBRpgl/68-tilstand-for-samtykkepanel-på-forsiden-skal-beholdes-når-man-navigerer-tilbake-fra-skjemasteget)

### Hvordan er det løst? 🧠

Vi la til om samtykke er bekreftet i `AppContext`. Dette blir da en hook som man kan hente og bruke for å sette samtykke og finne ut om samtykke har blitt satt. Når man da går til neste side så vil _staten_ til erSamtykkeBekreftet bli beholdt som den er. ( Dersom man hard refresher og så blir dette nullstilt igjen). 