### PR TITLE
Fiks bug ved at valgt språk ikke vises i Språkvelger

### DIFF
--- a/app/komponenter/språkvelger/språkvelger.tsx
+++ b/app/komponenter/språkvelger/språkvelger.tsx
@@ -5,13 +5,14 @@ import { GlobeIcon } from '@navikt/aksel-icons';
 import { useSpråk } from '~/hooks/contextHooks';
 
 export const Språkvelger = () => {
-  const [, settSpråk] = useSpråk();
+  const [språk, settSpråk] = useSpråk();
 
   return (
     <>
       <Select
         label={<Label />}
         className={`${css.språkvelger}`}
+        value={språk}
         onChange={endring => {
           settSpråk(endring.target.value as LocaleType);
         }}


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

For å få denne buggen måtte du: 

1. Velg nynorsk eller engelsk
2. Gå til neste steg
3. Gå tilbake

Da vil du se at bokmål er det som er selected når du kommer tilbake, men det er ikke det språket som er på siden. 

[Lenke til trello kort](https://trello.com/c/BJfoP4Vl/88-lagre-state-p%C3%A5-spr%C3%A5kvelger)

### Hvordan er det løst? 🧠

Eg og Sedric (@sedriccc ) fant en god løsning på det.
Ved å si at verdien i `Select` er satt til språket man har valgt, så vil den vise det valget som er i staten `språk`.

Se denne koden: 

```typescript
   <Select
      label={<Label />}
      className={`${css.språkvelger}`}
      value={språk} // Her henter vi språk som er state variabel fra contextet 
      onChange={endring => {
        settSpråk(endring.target.value as LocaleType); // Her endrer vi state variablen fra contextet
      }}
    >
      <option value={LocaleType.nb}>Norsk (Bokmål)</option>
      <option value={LocaleType.nn}>Norsk (Nynorsk)</option>
      <option value={LocaleType.en}>English</option>
    </Select>
```