### PR TITLE
Sett opp Dependabot 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "12:00"
+      timezone: "Europe/Oslo"
+    open-pull-requests-limit: 5
+    ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-      time: "12:00"
+      time: "12:30"
       timezone: "Europe/Oslo"
     open-pull-requests-limit: 5
     ignore:


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

Dependabot er et verktøy som automatiserer at pakker blir oppdatert riktig. 
Den lager kun PRer som man må manuelt gå igjennom og godkjenne for å få endringer. Dette gjer det mulig at man kan teste om ny pakke versjon krever 

Dependaboten vil blandt annet: 

- Si i fra når pakker bør oppdateres. [Link til relevant artikkel her.](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/)
- Si i fra når pakker har sårbarheter og skal oppdateres.  [Link til Github docs for Dependabot Security Updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates)
- Oppdage sikkerhetshull i koden og forslå endringer for å skrive sikker kode. [Mer info her](https://github.com/features/security)

Fordeler med å bruke Dependabot:

- **Stabilitet**: Alltid oppdatert til riktig pakker
- **Sikkerhet**: Pakker med sårbarheter blir funnet og oppdatert
- **Vedlikehold**: Enkelt vedlikehold flere pakker. Veldig nytting i større project. 


[Lenke til trello kort](https://trello.com/c/XHIjUj1s/44-få-opp-dependabot)

[Link til PR i bekk/nav-familie-endringsmelding-api som har samme mål](https://github.com/bekk/nav-familie-endringsmelding-api/pull/8)

### Hvordan er det løst? 🧠

Fekk admin tilgang og satt opp det i Github. 
Deretter la til et script for hvor ofte pakkene skal bli sett. 
Vi bestemte for å gjør dette kl. 12 hver dag og kvar 5 pull request som limit. 

<img width="842" alt="Screenshot 2023-07-03 at 14 03 17" src="https://github.com/bekk/nav-familie-endringsmelding/assets/31205453/7b27a41d-e220-472e-a88b-1b572645a02d">

