### PR TITLE
Fjern stylingvalg fra tekstblokk

### DIFF
--- a/app/komponenter/tekstblokk/TekstBlokk.tsx
+++ b/app/komponenter/tekstblokk/TekstBlokk.tsx
@@ -30,16 +30,6 @@ const TekstBlokk: React.FC<Props> = ({
               {children}
             </TypografiWrapper>
           ),
-          h1: ({ children }) => (
-            <TypografiWrapper typografi={typografi}>
-              {children}
-            </TypografiWrapper>
-          ),
-          h2: ({ children }) => (
-            <TypografiWrapper typografi={typografi}>
-              {children}
-            </TypografiWrapper>
-          ),
         },
         marks: {
           flettefelt: props => {


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

Styling av header skal ikke kunne endres i Sanity.  I sammenheng med [denne endringen i Sanity Studio](https://github.com/bekk/nav-familie-endringsmelding-sanity/pull/41), bør dette repo oppdateres for dette.
[Lenke til trello kort](https://trello.com/c/sqLizRYq/58-fjern-umulige-stylingvalg-i-sanity)

### Hvordan er det løst? 🧠
Har fjernet `h1` og `h2` fra `TekstBlokk`-komponenten. Usikker på om disse i utgangspunktet gjorde noe, da å fjerne dem ikke medførte noen endringer i UI. Styling av skrift defineres nå kun gjennom `TypografiWrapper`.