### PR TITLE
Overskrift kvitteringsside

### DIFF
--- a/app/routes/kvittering.tsx
+++ b/app/routes/kvittering.tsx
@@ -1,0 +1,20 @@
+import HovedInnhold from '~/komponenter/hovedInnhold/HovedInnhold';
+import { useTekster } from '~/hooks/contextHooks';
+import TekstBlokk from '~/komponenter/tekstblokk/TekstBlokk';
+import { ESanityMappe } from '~/typer/felles';
+import { ETypografiTyper } from '~/typer/typografi';
+import StegIndikator from '~/komponenter/stegindikator/StegIndikator';
+
+export default function Kvittering() {
+  const tekster = useTekster(ESanityMappe.KVITTERING);
+
+  return (
+    <HovedInnhold>
+      <StegIndikator nåværendeSteg={3} />
+      <TekstBlokk
+        tekstblokk={tekster.kvitteringTittel}
+        typografi={ETypografiTyper.STEG_HEADING_SMALL_H1}
+      />
+    </HovedInnhold>
+  );
+}

--- a/app/server/hentSanityData.server.ts
+++ b/app/server/hentSanityData.server.ts
@@ -26,6 +26,10 @@ export const hentSanityData = async (): Promise<ITekstinnhold> => {
       tekst,
       ESanityMappe.SEND_ENDRINGER,
     ),
+    [ESanityMappe.KVITTERING]: strukturerInnholdForSteg(
+      tekst,
+      ESanityMappe.KVITTERING,
+    ),
     [ESanityMappe.FELLES]: strukturerInnholdForSteg(tekst, ESanityMappe.FELLES),
   };
 

--- a/app/typer/felles.ts
+++ b/app/typer/felles.ts
@@ -7,10 +7,12 @@ export enum ELocaleType {
 export enum ESanityMappe {
   FORSIDE = 'FORSIDE',
   SEND_ENDRINGER = 'SEND_ENDRINGER',
+  KVITTERING = 'KVITTERING',
   FELLES = 'FELLES',
 }
 
 export enum ESteg {
   FORSIDE = 'FORSIDE',
   SEND_ENDRINGER = 'SEND_ENDRINGER',
+  KVITTERING = 'KVITTERING',
 }

--- a/app/typer/sanity/sanity.ts
+++ b/app/typer/sanity/sanity.ts
@@ -6,6 +6,7 @@ import {
   EApiKeysSendEndring,
   SendEndringTekstinnhold,
 } from './sanitySendEndring';
+import { EApiKeysKvittering, KvitteringTekstinnhold } from './sanityKvittering';
 
 export interface ISanityDokument {
   _createdAt: string;
@@ -32,7 +33,12 @@ export type FlettefeltVerdier = {
 export interface ITekstinnhold {
   [ESanityMappe.FORSIDE]: ForsideTekstinnhold;
   [ESanityMappe.SEND_ENDRINGER]: SendEndringTekstinnhold;
+  [ESanityMappe.KVITTERING]: KvitteringTekstinnhold;
   [ESanityMappe.FELLES]: FellesTekstinnhold;
 }
 
-export type ApiKeys = EApiKeysForside | EApiKeysSendEndring | EApiKeysFelles;
+export type ApiKeys =
+  | EApiKeysForside
+  | EApiKeysSendEndring
+  | EApiKeysKvittering
+  | EApiKeysFelles;

--- a/app/typer/sanity/sanityKvittering.ts
+++ b/app/typer/sanity/sanityKvittering.ts
@@ -1,0 +1,10 @@
+import { ISanityDokument } from './sanity';
+
+export enum EApiKeysKvittering {
+  TITTEL = 'kvitteringTittel',
+}
+
+export type KvitteringTekstinnhold = Record<
+  EApiKeysKvittering,
+  ISanityDokument
+>;

--- a/app/utils/hentPathForSteg.ts
+++ b/app/utils/hentPathForSteg.ts
@@ -6,6 +6,8 @@ export const hentPathForSteg = (steg: ESteg) => {
       return '/';
     case ESteg.SEND_ENDRINGER:
       return '/send-endringsmelding';
+    case ESteg.KVITTERING:
+      return '/kvittering';
     default:
       return '/'; //bør i fremtiden vise til feilmelding-side + error handling
   }


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
Kvittering siden for mottatt endring trenger en overskrift 

[Lenke til trello kort](https://trello.com/c/b24Okswk/84-overskrift-kvitteringsside)

### Hvordan er det løst? 🧠
Vi lagde en tekstblokk med typografi h1 som er overskiften. Vi har koblet kvitterings siden opp mot sanity

![image](https://github.com/bekk/nav-familie-endringsmelding/assets/31205453/e9279b3d-139f-4563-83e4-e658ee2c0754)

