### PR TITLE
UU-feil

### DIFF
--- a/app/komponenter/banner/Banner.tsx
+++ b/app/komponenter/banner/Banner.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 const Banner: React.FC<Props> = ({ tekst }) => {
   return (
-    <section className={`${css.bannerStil}`}>
+    <section className={`${css.bannerStil}`} role="banner">
       {typeof tekst === 'string' ? (
         <Heading level="1" size="large">
           {tekst}

--- a/app/komponenter/feilside/Feilside.tsx
+++ b/app/komponenter/feilside/Feilside.tsx
@@ -9,6 +9,7 @@ const Feilside: React.FC = () => {
   return (
     <html lang={ELocaleType.NB}>
       <head>
+        <title>Endringsmelding</title>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />

--- a/app/komponenter/språkvelger/språkvelger.tsx
+++ b/app/komponenter/språkvelger/språkvelger.tsx
@@ -13,6 +13,7 @@ export const Språkvelger = () => {
         label={<Label />}
         className={`${css.språkvelger}`}
         value={språk}
+        autoComplete="on"
         onChange={endring => {
           settSpråk(endring.target.value as ELocaleType);
         }}
@@ -28,7 +29,7 @@ export const Språkvelger = () => {
 const Label = () => {
   return (
     <div className={`${css.label}`}>
-      <GlobeIcon title="a11y-title" fontSize={'1.5rem'} />
+      <GlobeIcon title="a11y-title" fontSize={'1.5rem'} aria-hidden={false} />
       <span> Språk/language </span>
     </div>
   );

--- a/app/komponenter/språkvelger/språkvelger.tsx
+++ b/app/komponenter/språkvelger/språkvelger.tsx
@@ -29,7 +29,7 @@ export const Språkvelger = () => {
 const Label = () => {
   return (
     <div className={`${css.label}`}>
-      <GlobeIcon title="globe-icon" fontSize={'1.5rem'} aria-hidden={false} />
+      <GlobeIcon title="globe-icon" fontSize={'1.5rem'} />
       <span> Språk/language </span>
     </div>
   );

--- a/app/komponenter/språkvelger/språkvelger.tsx
+++ b/app/komponenter/språkvelger/språkvelger.tsx
@@ -29,7 +29,7 @@ export const Språkvelger = () => {
 const Label = () => {
   return (
     <div className={`${css.label}`}>
-      <GlobeIcon title="a11y-title" fontSize={'1.5rem'} aria-hidden={false} />
+      <GlobeIcon title="globe-icon" fontSize={'1.5rem'} aria-hidden={false} />
       <span> Språk/language </span>
     </div>
   );

--- a/app/komponenter/stegindikator/StegIndikator.tsx
+++ b/app/komponenter/stegindikator/StegIndikator.tsx
@@ -11,7 +11,6 @@ const StegIndikator: React.FC<Props> = ({ nåværendeSteg }) => {
   return (
     <Stepper
       className={`${css.stegIndikator}`}
-      aria-labelledby="stepper-heading"
       activeStep={nåværendeSteg}
       interactive={false}
       orientation="horizontal"

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -98,6 +98,7 @@ export function Dokument({ children, språk = ELocaleType.NB }: DokumentProps) {
   return (
     <html lang={språk}>
       <head>
+        <title>Endringsmelding</title>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
@@ -118,9 +119,13 @@ export function Oppsett({ children }: OppsettProps) {
 
   return (
     <>
-      {parse(dekoratørFragmenter.DECORATOR_HEADER, { trim: true })}
+      <div role="navigation">
+        {parse(dekoratørFragmenter.DECORATOR_HEADER, { trim: true })}
+      </div>
       {children}
-      {parse(dekoratørFragmenter.DECORATOR_FOOTER, { trim: true })}
+      <div role="navigation">
+        {parse(dekoratørFragmenter.DECORATOR_FOOTER, { trim: true })}
+      </div>
     </>
   );
 }

--- a/app/routes/send-endringsmelding.tsx
+++ b/app/routes/send-endringsmelding.tsx
@@ -84,7 +84,6 @@ export default function SendEndringsmelding() {
         typografi={ETypografiTyper.STEG_HEADING_SMALL_H1}
       />
       <Veiledning />
-
       <Textarea
         label={<TekstBlokk tekstblokk={tekster.fritekstfeltTittel} />}
         description={
@@ -92,6 +91,7 @@ export default function SendEndringsmelding() {
         }
         maxLength={MAKS_INPUT_LENGDE}
         className={`${css.fullBredde}`}
+        autoComplete="on"
         i18n={i18nInnhold}
         error={!tekstInputOK && knappTrykketPå && utledFeilmelding()}
         onInput={event => {


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

Det er nødvendig å ta i bruk et verktøy som ARC Toolkit for å oppdage UU-feil. I tillegg er det viktig å teste at funksjonaliteten fungerer når man bare bruker tastatur og at innholdet leses opp på en forklarlig måte. 

[Lenke til trello kort](https://trello.com/c/aIAK9Jfn/103-fikse-uu-feil)

### Hvordan er det løst? 🧠

[Aksel](https://aksel.nav.no/god-praksis/artikler/utvikling) oppsummerer en del om god praksis og hvordan skrive tilgjengelig kode. Noen key takeaways er:

- Bruk lang-attributtet på html-elementet 
- Strukturer hele siden i én serie med headings
- Bruk landmarks til å dele innholdet inn i seksjoner
- Bruk semantiske elementer som lister, tabeller og figure + figcaption
- Prøv å oppretteholde en logisk rekkefølge til HTMLen din

Og tips for testing av koden er:
- Sett opp automatisk verktøy
- Bruk testverktøy
- Test med tastatur 
- Test med skjermleser

Vi kan vurdere om det er lurt å sette opp noe automatisk verktøy for dette. 

Når det gjelder testverktøy har jeg valgt å bruke **ARC Toolkit** da dette var nevnt i Aksel og hadde få cons når man så på de forskjellige annet enn at det krevde litt teknisk erfaring. 

Sånn her gikk jeg fram for å bruke ARC Toolkit:
1. Lastet ned extension for Google Chrome: https://chrome.google.com/webstore/detail/arc-toolkit/chdkkkccnlfncngelccgbgfmjebmkmce
2. Kjørte appen lokalt, åpnet “Inspect” og fant ARC Toolkit øverst til høyre i inspect menyen
3. Kjøre testen ved å klikke på "Run tests"

Resultatet så noe sånn her ut:
<img width="1178" alt="Screenshot 2023-07-10 at 15 45 36" src="https://github.com/bekk/nav-familie-endringsmelding/assets/54811230/84a049b1-91cb-4033-a78f-ed2d31b4d829">

Basert på dette er endingene som er gjort:
- La til title i `Dokument` og `Feilside`
- La til  autoComplete="on" på `Språkvelger` og `Textarea`
- Fjernet aria-labelledby på `StegIndikator` da dette var "Bad ARIA attribute. The element uses an invalid ARIA attribute."


I tillegg **testet jeg med tastatur,** se her:

https://github.com/bekk/nav-familie-endringsmelding/assets/54811230/32d6f93f-c3b8-4312-93f5-0cda9229b439

Da er det bare å sette musen øverst i venstre hjørne og trykke på Tab for å bevege seg gjennom siden. 
Fant ingen problemer her. 

Til slutt brukte jeg **VoiceOver** som er innebygd på Mac ved å gå til Settings -> Accessibility -> VoiceOver og huket av på å bruke det. 
Ved å gjøre dette la jeg merke til:
- at navigasjonen ble lest opp som banner og at banneret bare ble nevnt som heading og ikke banner
- at den leste opp ikonet av globusen som a11y-title som var lite forståelig
- at den hoppet over stepperen. 
- (og at jeg har skikkelig respekt for de som bruker det til vanlig!)

Endringer gjort utifra denne testen er:
- diver med role=navigation rundt header og footer for dekoratøren
- role= banner på banneret
- endret title på globe iconet
Landet på at stepperen skal hoppes over når den ikke er interaktiv. 


