### PR TITLE
Fiks typografi slik at feilmelding fjernes

### DIFF
--- a/app/komponenter/samtykkepanel/SamtykkePanel.tsx
+++ b/app/komponenter/samtykkepanel/SamtykkePanel.tsx
@@ -30,7 +30,12 @@ const SamtykkePanel: React.FC<Props> = ({
       />
       <ConfirmationPanel
         checked={erSamtykkeBekreftet}
-        label={<TekstBlokk tekstblokk={tekster.samtykkePanelSamtykke} />}
+        label={
+          <TekstBlokk
+            tekstblokk={tekster.samtykkePanelSamtykke}
+            typografi={ETypografiTyper.SPAN}
+          />
+        }
         onChange={() => {
           vedSamtykkeEndring(!erSamtykkeBekreftet);
         }}
@@ -39,8 +44,8 @@ const SamtykkePanel: React.FC<Props> = ({
           feilmeldingAktivert && (
             <TekstBlokk
               tekstblokk={tekster.samtykkePanelFeilmelding}
-              typografi={ETypografiTyper.BODY_SHORT}
-            /> //denne gir feilmelding fordi den ikke er en ren String ("kan ikke være i <p>"). Visuelt fungerer den.
+              typografi={ETypografiTyper.LABEL}
+            />
           )
         }
       >

--- a/app/routes/send-endringsmelding.tsx
+++ b/app/routes/send-endringsmelding.tsx
@@ -56,14 +56,25 @@ export default function SendEndringsmelding() {
   const utledFeilmelding = () => {
     if (manglerTekst) {
       return (
-        <TekstBlokk tekstblokk={tekster.fritekstfeltFeilmeldingManglerTekst} />
+        <TekstBlokk
+          tekstblokk={tekster.fritekstfeltFeilmeldingManglerTekst}
+          typografi={ETypografiTyper.LABEL}
+        />
       );
     } else if (brukerSpesialtegn) {
       return (
-        <TekstBlokk tekstblokk={tekster.fritekstfeltFeilmeldingSpesialTegn} />
+        <TekstBlokk
+          tekstblokk={tekster.fritekstfeltFeilmeldingSpesialTegn}
+          typografi={ETypografiTyper.LABEL}
+        />
       );
     } else if (!minimumTegnOppfylt) {
-      return <TekstBlokk tekstblokk={tekster.fritekstfeltFeilmeldingMinTegn} />;
+      return (
+        <TekstBlokk
+          tekstblokk={tekster.fritekstfeltFeilmeldingMinTegn}
+          typografi={ETypografiTyper.LABEL}
+        />
+      );
     }
   };
 

--- a/app/typer/typografi.ts
+++ b/app/typer/typografi.ts
@@ -5,4 +5,5 @@ export enum ETypografiTyper {
   BANNER_HEADING = 'BANNER_HEADING',
   BODY_SHORT = 'BODY_SHORT',
   LABEL = 'LABEL',
+  SPAN = 'SPAN',
 }

--- a/app/utils/TypografiWrapper.tsx
+++ b/app/utils/TypografiWrapper.tsx
@@ -41,7 +41,10 @@ export const TypografiWrapper: React.FC<Props> = ({
         </Heading>
       );
     case ETypografiTyper.LABEL:
-      return <Label>{children}</Label>;
+      return <Label style={style}>{children}</Label>;
+
+    case ETypografiTyper.SPAN:
+      return <span style={style}>{children}</span>;
 
     default:
       return <div style={style}>{children}</div>;


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

Vi har fått opp feilmeldinger i konsollen for typografityper i tekstblokk, av typen `<p> can not be inside of <p>`
[Lenke til trello kort](https://trello.com/c/jKO0lsnq/114-se-på-mulighetene-for-å-kun-returnere-string-i-tekstblokk-for-å-slippe-warnings-error)

### Hvordan er det løst? 🧠
Har endret typografitypen der feilmeldingen trigges. De fleste stedene gjelder dette `LABEL`. Har også lagt til en TypografiType for `SPAN`, til bruk der feilmelding trigges hvor label ikke blir korrekt (ikke fet skrift).