### PR TITLE
Fikse tester veileder

### DIFF
--- a/app/komponenter/veilederpanel/VeilederPanel.tsx
+++ b/app/komponenter/veilederpanel/VeilederPanel.tsx
@@ -19,6 +19,7 @@ const VeilederPanel: React.FC<Props> = ({
     <GuidePanel
       poster={poster}
       className={poster ? `${css.poster}` : `${css.veilederPanel}`}
+      data-testid="veilederPanel"
     >
       {overskrift && (
         <div className={`${css.tekstInnholdMellomrom}`}>{overskrift}</div>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -57,6 +57,7 @@ export default function Index() {
       tekstblokk={tekster.brukerHilsen}
       typografi={ETypografiTyper.HEADING_H2}
       flettefelter={{ søkerNavn: hentSøkerFornavn(søker) }}
+      dataTestid="hilsenFornavn"
     />
   );
 

--- a/cypress/e2e/steg1.cy.ts
+++ b/cypress/e2e/steg1.cy.ts
@@ -6,7 +6,7 @@ describe('Steg1-test', () => {
     cy.get(`[data-testid='overskriftSteg1']`).contains('Send endringer');
   });
   it('Finner tekst i veiledning', () => {
-    cy.get(`[data-testid='veiledningSteg1']`).contains(
+    cy.get(`[data-testid='veilederPanel']`).contains(
       'Veiledning på endringsmelding',
     );
   });


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
Felleskomponenten for VeilederPanel glemte å ta stilling til tester 👀 , så det måtte fikses. Er lagt tilbake test-id for overskrift på forside, og en test-id for veilederpanelet.