### PR TITLE
Lag komponent for forside

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,25 +1,6 @@
-import { Button } from '@navikt/ds-react';
 import type { V2_MetaFunction } from '@remix-run/node';
-import { useNavigate } from '@remix-run/react';
-import { useState } from 'react';
 
-import {
-  useBekreftetSamtykke,
-  useSøker,
-  useTekster,
-} from '~/hooks/contextHooks';
-import HovedInnhold from '~/komponenter/hovedInnhold/HovedInnhold';
-import SamtykkePanel from '~/komponenter/samtykkepanel/SamtykkePanel';
-import Spinner from '~/komponenter/Spinner';
-import { Språkvelger } from '~/komponenter/språkvelger/språkvelger';
-import TekstBlokk from '~/komponenter/tekstblokk/TekstBlokk';
-import VeilederPanel from '~/komponenter/veilederpanel/VeilederPanel';
-import { ESanityMappe, ESteg } from '~/typer/felles';
-import { ETypografiTyper } from '~/typer/typografi';
-import { hentPathForSteg } from '~/utils/hentPathForSteg';
-import { hentSøkerFornavn } from '~/utils/hentSøkerInfo';
-
-import css from './_index.module.css';
+import Forside from '~/sider/Forside';
 
 export const meta: V2_MetaFunction = () => {
   return [
@@ -33,72 +14,5 @@ export const meta: V2_MetaFunction = () => {
 };
 
 export default function Index() {
-  const [erSamtykkeBekreftet] = useBekreftetSamtykke();
-  const tekster = useTekster(ESanityMappe.FORSIDE);
-  const { knappStart } = useTekster(ESanityMappe.FELLES);
-
-  const [erFeilmeldingAktivert, settErFeilmeldingAktivert] = useState(false);
-
-  const navigate = useNavigate();
-
-  const håndterSamtykkeEndring = () => {
-    settErFeilmeldingAktivert(false);
-  };
-
-  const håndterTrykkStart = () => {
-    if (erSamtykkeBekreftet) {
-      navigate(hentPathForSteg(ESteg.SEND_ENDRINGER));
-    } else {
-      settErFeilmeldingAktivert(true);
-    }
-  };
-
-  const søker = useSøker();
-  const hentBrukerhilsen = (
-    <TekstBlokk
-      tekstblokk={tekster.brukerHilsen}
-      typografi={ETypografiTyper.HEADING_H2}
-      flettefelter={{ søkerNavn: hentSøkerFornavn(søker) }}
-      dataTestid="hilsenFornavn"
-    />
-  );
-
-  return (
-    <HovedInnhold>
-      {!tekster ? (
-        <Spinner />
-      ) : (
-        <>
-          <div className={`${css.toppMargin}`} data-testid="forsideTittel">
-            <TekstBlokk
-              tekstblokk={tekster.tittel}
-              typografi={ETypografiTyper.HEADING_H1}
-            />
-          </div>
-          <Språkvelger />
-
-          <VeilederPanel
-            innhold={tekster.veilederhilsenInnhold}
-            poster={true}
-            overskrift={hentBrukerhilsen}
-          />
-          <SamtykkePanel
-            håndterSamtykkeEndring={håndterSamtykkeEndring}
-            feilmeldingAktivert={erFeilmeldingAktivert}
-          />
-          <Button
-            variant={erSamtykkeBekreftet ? 'primary' : 'secondary'}
-            onClick={håndterTrykkStart}
-            data-testid="startKnapp"
-          >
-            <TekstBlokk tekstblokk={knappStart} />
-          </Button>
-          <TekstBlokk
-            tekstblokk={tekster.linkTilPersonvernerklaering}
-            dataTestid="linkPersonvern"
-          />
-        </>
-      )}
-    </HovedInnhold>
-  );
+  return <Forside />;
 }

--- a/app/sider/Forside.tsx
+++ b/app/sider/Forside.tsx
@@ -25,18 +25,10 @@ const Forside: React.FC = () => {
   const { knappStart } = useTekster(ESanityMappe.FELLES);
   const søker = useSøker();
   const [erSamtykkeBekreftet] = useBekreftetSamtykke();
+
   const navigate = useNavigate();
 
   const [erFeilmeldingAktivert, settErFeilmeldingAktivert] = useState(false);
-
-  const hentBrukerhilsen = (
-    <TekstBlokk
-      tekstblokk={tekster.brukerHilsen}
-      typografi={ETypografiTyper.HEADING_H2}
-      flettefelter={{ søkerNavn: hentSøkerFornavn(søker) }}
-      dataTestid="hilsenFornavn"
-    />
-  );
 
   const håndterSamtykkeEndring = () => {
     settErFeilmeldingAktivert(false);
@@ -67,7 +59,14 @@ const Forside: React.FC = () => {
           <VeilederPanel
             innhold={tekster.veilederhilsenInnhold}
             poster={true}
-            overskrift={hentBrukerhilsen}
+            overskrift={
+              <TekstBlokk
+                tekstblokk={tekster.brukerHilsen}
+                typografi={ETypografiTyper.HEADING_H2}
+                flettefelter={{ søkerNavn: hentSøkerFornavn(søker) }}
+                dataTestid="hilsenFornavn"
+              />
+            }
           />
           <SamtykkePanel
             håndterSamtykkeEndring={håndterSamtykkeEndring}

--- a/app/sider/Forside.tsx
+++ b/app/sider/Forside.tsx
@@ -1,0 +1,93 @@
+import { Button } from '@navikt/ds-react';
+import { useNavigate } from '@remix-run/react';
+import { useState } from 'react';
+
+import {
+  useBekreftetSamtykke,
+  useSøker,
+  useTekster,
+} from '~/hooks/contextHooks';
+import HovedInnhold from '~/komponenter/hovedInnhold/HovedInnhold';
+import SamtykkePanel from '~/komponenter/samtykkepanel/SamtykkePanel';
+import Spinner from '~/komponenter/Spinner';
+import { Språkvelger } from '~/komponenter/språkvelger/språkvelger';
+import TekstBlokk from '~/komponenter/tekstblokk/TekstBlokk';
+import VeilederPanel from '~/komponenter/veilederpanel/VeilederPanel';
+import { ESanityMappe, ESteg } from '~/typer/felles';
+import { ETypografiTyper } from '~/typer/typografi';
+import { hentPathForSteg } from '~/utils/hentPathForSteg';
+import { hentSøkerFornavn } from '~/utils/hentSøkerInfo';
+
+import css from '../routes/_index.module.css';
+
+export const Forside: React.FC = () => {
+  const tekster = useTekster(ESanityMappe.FORSIDE);
+  const { knappStart } = useTekster(ESanityMappe.FELLES);
+  const søker = useSøker();
+  const [erSamtykkeBekreftet] = useBekreftetSamtykke();
+  const navigate = useNavigate();
+
+  const [erFeilmeldingAktivert, settErFeilmeldingAktivert] = useState(false);
+
+  const hentBrukerhilsen = (
+    <TekstBlokk
+      tekstblokk={tekster.brukerHilsen}
+      typografi={ETypografiTyper.HEADING_H2}
+      flettefelter={{ søkerNavn: hentSøkerFornavn(søker) }}
+      dataTestid="hilsenFornavn"
+    />
+  );
+
+  const håndterSamtykkeEndring = () => {
+    settErFeilmeldingAktivert(false);
+  };
+
+  const håndterTrykkStart = () => {
+    if (erSamtykkeBekreftet) {
+      navigate(hentPathForSteg(ESteg.SEND_ENDRINGER));
+    } else {
+      settErFeilmeldingAktivert(true);
+    }
+  };
+
+  return (
+    <HovedInnhold>
+      {!tekster ? (
+        <Spinner />
+      ) : (
+        <>
+          <div className={`${css.toppMargin}`} data-testid="forsideTittel">
+            <TekstBlokk
+              tekstblokk={tekster.tittel}
+              typografi={ETypografiTyper.HEADING_H1}
+            />
+          </div>
+          <Språkvelger />
+
+          <VeilederPanel
+            innhold={tekster.veilederhilsenInnhold}
+            poster={true}
+            overskrift={hentBrukerhilsen}
+          />
+          <SamtykkePanel
+            håndterSamtykkeEndring={håndterSamtykkeEndring}
+            feilmeldingAktivert={erFeilmeldingAktivert}
+          />
+          <Button
+            variant={erSamtykkeBekreftet ? 'primary' : 'secondary'}
+            onClick={håndterTrykkStart}
+            data-testid="startKnapp"
+          >
+            <TekstBlokk tekstblokk={knappStart} />
+          </Button>
+          <TekstBlokk
+            tekstblokk={tekster.linkTilPersonvernerklaering}
+            dataTestid="linkPersonvern"
+          />
+        </>
+      )}
+    </HovedInnhold>
+  );
+};
+
+export default Forside;

--- a/app/sider/Forside.tsx
+++ b/app/sider/Forside.tsx
@@ -20,7 +20,7 @@ import { hentSøkerFornavn } from '~/utils/hentSøkerInfo';
 
 import css from '../routes/_index.module.css';
 
-export const Forside: React.FC = () => {
+const Forside: React.FC = () => {
   const tekster = useTekster(ESanityMappe.FORSIDE);
   const { knappStart } = useTekster(ESanityMappe.FELLES);
   const søker = useSøker();


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
For at alle stønadsinngangene skal kunne føre til en forside som er relativt lik bortsett fra teksten skal det lages en komponent for forsiden som kan gjenbrukes. 

[Lenke til trello kort](https://trello.com/c/XLkwb8zb/122-egen-komponent-for-forside)

### Hvordan er det løst? 🧠
Mappen `sider` er lagt til i `app` og det er laget en ny komponent `Forside.tsx` i denne mappen. Innholdet fra `_index.tsx` er flyttet inn i denne nye komponenten. I tillegg er rekkefølgen på const-ene og funksjonene litt endret, og const for `hentBrukerHilsen` fjernet og satt direkte inn i overskrift propen til `VeilderPanel`
