### PR TITLE
En egen komponent for kvitterinsSiden

### DIFF
--- a/app/routes/kvittering.tsx
+++ b/app/routes/kvittering.tsx
@@ -1,24 +1,5 @@
-import { useTekster } from '~/hooks/contextHooks';
-import BekreftelseBoks from '~/komponenter/bekreftelsesboks/Bekreftelseboks';
-import HovedInnhold from '~/komponenter/hovedInnhold/HovedInnhold';
-import StegIndikator from '~/komponenter/stegindikator/StegIndikator';
-import TekstBlokk from '~/komponenter/tekstblokk/TekstBlokk';
-import VeilederPanel from '~/komponenter/veilederpanel/VeilederPanel';
-import { ESanityMappe } from '~/typer/felles';
-import { ETypografiTyper } from '~/typer/typografi';
+import KvitteringSide from '~/sider/kvitteringSide';
 
 export default function Kvittering() {
-  const tekster = useTekster(ESanityMappe.KVITTERING);
-
-  return (
-    <HovedInnhold>
-      <StegIndikator nåværendeSteg={3} />
-      <TekstBlokk
-        tekstblokk={tekster.kvitteringTittel}
-        typografi={ETypografiTyper.STEG_HEADING_SMALL_H1}
-      />
-      <BekreftelseBoks />
-      <VeilederPanel innhold={tekster.kvitteringVeileder} />
-    </HovedInnhold>
-  );
+  return <KvitteringSide />;
 }

--- a/app/sider/kvitteringSide.tsx
+++ b/app/sider/kvitteringSide.tsx
@@ -1,0 +1,24 @@
+import { useTekster } from '~/hooks/contextHooks';
+import BekreftelseBoks from '~/komponenter/bekreftelsesboks/Bekreftelseboks';
+import HovedInnhold from '~/komponenter/hovedInnhold/HovedInnhold';
+import StegIndikator from '~/komponenter/stegindikator/StegIndikator';
+import TekstBlokk from '~/komponenter/tekstblokk/TekstBlokk';
+import VeilederPanel from '~/komponenter/veilederpanel/VeilederPanel';
+import { ESanityMappe } from '~/typer/felles';
+import { ETypografiTyper } from '~/typer/typografi';
+
+export default function KvitteringSide() {
+  const tekster = useTekster(ESanityMappe.KVITTERING);
+
+  return (
+    <HovedInnhold>
+      <StegIndikator nåværendeSteg={3} />
+      <TekstBlokk
+        tekstblokk={tekster.kvitteringTittel}
+        typografi={ETypografiTyper.STEG_HEADING_SMALL_H1}
+      />
+      <BekreftelseBoks />
+      <VeilederPanel innhold={tekster.kvitteringVeileder} />
+    </HovedInnhold>
+  );
+}


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

For at kvittering komponent skal brukes på alle kvitteringsider til alle stønader så skal det være en egen komponent 
[Lenke til trello kort](https://trello.com/c/hmqia0Zb/123-eget-komponent-for-kvittering)

### Hvordan er det løst? 🧠

Mappen sider er lagt til i app og det er laget en ny komponent kvitteringSide.tsx i denne mappen og inneholder det man trenger for en kvittering. KvitteringsSide ble laget som et eget komponent så den kan brukes på alle stønader. 
