### PR TITLE
Lage send endring side komponent

### DIFF
--- a/app/routes/send-endringsmelding.tsx
+++ b/app/routes/send-endringsmelding.tsx
@@ -9,7 +9,6 @@ import { RESPONSE_STATUS_FEIL } from '~/typer/response';
 export async function action({ request }: ActionArgs) {
   const formData = await request.formData();
   const endringsmelding = formData.get('endringsmelding') as string;
-  console.log(endringsmelding);
   return await sendEndringsmelding(
     endringsmelding,
     await getSession(request.headers.get('Cookie')),

--- a/app/routes/send-endringsmelding.tsx
+++ b/app/routes/send-endringsmelding.tsx
@@ -1,39 +1,15 @@
-import { Alert, Button, Textarea } from '@navikt/ds-react';
 import { ActionArgs } from '@remix-run/node';
-import { Form, useActionData, useNavigate, useSubmit } from '@remix-run/react';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
-import {
-  useEndringsmeldingMottattDato,
-  useSpråk,
-  useTekster,
-} from '~/hooks/contextHooks';
-import HovedInnhold from '~/komponenter/hovedInnhold/HovedInnhold';
-import StegIndikator from '~/komponenter/stegindikator/StegIndikator';
-import TekstBlokk from '~/komponenter/tekstblokk/TekstBlokk';
-import VeilederPanel from '~/komponenter/veilederpanel/VeilederPanel';
 import { sendEndringsmelding } from '~/server/sendEndringsmelding.server';
 import { getSession } from '~/sessions';
-import { ESanityMappe, ESteg } from '~/typer/felles';
-import { EFritekstFeil, fritekstFeilTilApiKeys } from '~/typer/fritekstfeil';
-import {
-  IPostResponse,
-  RESPONSE_STATUS_FEIL,
-  RESPONSE_STATUS_OK,
-} from '~/typer/response';
-import { ETypografiTyper } from '~/typer/typografi';
-import {
-  i18nInnhold,
-  MAKS_INPUT_LENGDE,
-  validerTekst,
-} from '~/utils/fritekstfeltValidering';
-import { hentPathForSteg } from '~/utils/hentPathForSteg';
-
-import css from './send-endringsmelding.module.css';
+import SendEndringSide from '~/sider/SendEndring';
+import { RESPONSE_STATUS_FEIL } from '~/typer/response';
 
 export async function action({ request }: ActionArgs) {
   const formData = await request.formData();
   const endringsmelding = formData.get('endringsmelding') as string;
+  console.log(endringsmelding);
   return await sendEndringsmelding(
     endringsmelding,
     await getSession(request.headers.get('Cookie')),
@@ -44,112 +20,5 @@ export async function action({ request }: ActionArgs) {
 }
 
 export default function SendEndringsmelding() {
-  const actionData: IPostResponse | undefined = useActionData<typeof action>();
-  const submit = useSubmit();
-
-  const tekster = useTekster(ESanityMappe.SEND_ENDRINGER);
-  const teksterFelles = useTekster(ESanityMappe.FELLES);
-  const navigate = useNavigate();
-  const [språk] = useSpråk();
-  const [, settEndringsmeldingMottattDato] = useEndringsmeldingMottattDato();
-
-  const [erResponseOK, settErResponseOK] = useState<boolean>(true);
-  const [valideringsfeil, settValideringsfeil] = useState<EFritekstFeil | null>(
-    EFritekstFeil.MANGLER_TEKST,
-  );
-  const [erKnappTrykketPå, settKnappTrykketPå] = useState<boolean>(false);
-
-  useEffect(() => {
-    if (!actionData) return;
-
-    if (actionData.text === RESPONSE_STATUS_OK && actionData.mottattDato) {
-      settEndringsmeldingMottattDato(actionData.mottattDato);
-      navigate(hentPathForSteg(ESteg.KVITTERING));
-    } else {
-      settErResponseOK(false);
-    }
-  }, [actionData, navigate, settEndringsmeldingMottattDato]);
-
-  function genererFeilmelding() {
-    return (
-      erKnappTrykketPå &&
-      valideringsfeil && (
-        <TekstBlokk
-          tekstblokk={tekster[fritekstFeilTilApiKeys[valideringsfeil]]}
-          typografi={ETypografiTyper.LABEL}
-        />
-      )
-    );
-  }
-
-  function håndterSendEndringsmelding(
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-  ) {
-    event.preventDefault();
-    if (valideringsfeil === null) {
-      settErResponseOK(true);
-      submit(event.currentTarget, { replace: true });
-    }
-    settKnappTrykketPå(true);
-  }
-
-  return (
-    <HovedInnhold>
-      <StegIndikator nåværendeSteg={1} />
-      <TekstBlokk
-        tekstblokk={tekster.overskrift}
-        typografi={ETypografiTyper.STEG_HEADING_SMALL_H1}
-        dataTestid="overskriftSteg1"
-      />
-      <VeilederPanel innhold={tekster.veilederInnhold} />
-      <Form method="post" className={`${css.fullBredde}`}>
-        <Textarea
-          data-testid="fritekstfelt"
-          name="endringsmelding"
-          label={
-            <TekstBlokk
-              tekstblokk={tekster.fritekstfeltTittel}
-              dataTestid="fritekstfeltTittel"
-            />
-          }
-          description={
-            <TekstBlokk tekstblokk={tekster.fritekstfeltBeskrivelse} />
-          }
-          autoComplete="on"
-          maxLength={MAKS_INPUT_LENGDE}
-          i18n={i18nInnhold(språk)}
-          error={genererFeilmelding()}
-          onInput={event => {
-            settValideringsfeil(validerTekst(event.currentTarget.value));
-          }}
-        />
-        {!erResponseOK && (
-          <Alert variant="error" className={`${css.toppMargin}`}>
-            <TekstBlokk
-              tekstblokk={tekster.alertFeilUnderSendEndringsmelding}
-            />
-          </Alert>
-        )}
-        <div className={`${css.navigeringsKnappKonteiner}`}>
-          <Button
-            type="button"
-            variant={'secondary'}
-            onClick={() => navigate(hentPathForSteg(ESteg.FORSIDE))}
-          >
-            <TekstBlokk tekstblokk={teksterFelles.knappTilbake} />
-          </Button>
-          <Button
-            type="submit"
-            variant={valideringsfeil === null ? 'primary' : 'secondary'}
-            data-testid="knappVidereSteg1"
-            onClick={event => {
-              håndterSendEndringsmelding(event);
-            }}
-          >
-            <TekstBlokk tekstblokk={teksterFelles.knappSendEndringer} />
-          </Button>
-        </div>
-      </Form>
-    </HovedInnhold>
-  );
+  return <SendEndringSide />;
 }

--- a/app/sider/SendEndring.tsx
+++ b/app/sider/SendEndring.tsx
@@ -1,5 +1,4 @@
 import { Alert, Button, Textarea } from '@navikt/ds-react';
-import { ActionArgs } from '@remix-run/node';
 import { Form, useActionData, useNavigate, useSubmit } from '@remix-run/react';
 import React, { useEffect, useState } from 'react';
 
@@ -12,15 +11,10 @@ import HovedInnhold from '~/komponenter/hovedInnhold/HovedInnhold';
 import StegIndikator from '~/komponenter/stegindikator/StegIndikator';
 import TekstBlokk from '~/komponenter/tekstblokk/TekstBlokk';
 import VeilederPanel from '~/komponenter/veilederpanel/VeilederPanel';
-import { sendEndringsmelding } from '~/server/sendEndringsmelding.server';
-import { getSession } from '~/sessions';
+import { action } from '~/routes/send-endringsmelding';
 import { ESanityMappe, ESteg } from '~/typer/felles';
 import { EFritekstFeil, fritekstFeilTilApiKeys } from '~/typer/fritekstfeil';
-import {
-  IPostResponse,
-  RESPONSE_STATUS_FEIL,
-  RESPONSE_STATUS_OK,
-} from '~/typer/response';
+import { IPostResponse, RESPONSE_STATUS_OK } from '~/typer/response';
 import { ETypografiTyper } from '~/typer/typografi';
 import {
   i18nInnhold,
@@ -30,18 +24,6 @@ import {
 import { hentPathForSteg } from '~/utils/hentPathForSteg';
 
 import css from './../routes/send-endringsmelding.module.css';
-
-export async function action({ request }: ActionArgs) {
-  const formData = await request.formData();
-  const endringsmelding = formData.get('endringsmelding') as string;
-  return await sendEndringsmelding(
-    endringsmelding,
-    await getSession(request.headers.get('Cookie')),
-  ).then(response => {
-    if (response.ok) return response.json();
-    return { text: RESPONSE_STATUS_FEIL };
-  });
-}
 
 export default function SendEndringSide() {
   const actionData: IPostResponse | undefined = useActionData<typeof action>();

--- a/app/sider/SendEndring.tsx
+++ b/app/sider/SendEndring.tsx
@@ -1,0 +1,155 @@
+import { Alert, Button, Textarea } from '@navikt/ds-react';
+import { ActionArgs } from '@remix-run/node';
+import { Form, useActionData, useNavigate, useSubmit } from '@remix-run/react';
+import React, { useEffect, useState } from 'react';
+
+import {
+  useEndringsmeldingMottattDato,
+  useSpråk,
+  useTekster,
+} from '~/hooks/contextHooks';
+import HovedInnhold from '~/komponenter/hovedInnhold/HovedInnhold';
+import StegIndikator from '~/komponenter/stegindikator/StegIndikator';
+import TekstBlokk from '~/komponenter/tekstblokk/TekstBlokk';
+import VeilederPanel from '~/komponenter/veilederpanel/VeilederPanel';
+import { sendEndringsmelding } from '~/server/sendEndringsmelding.server';
+import { getSession } from '~/sessions';
+import { ESanityMappe, ESteg } from '~/typer/felles';
+import { EFritekstFeil, fritekstFeilTilApiKeys } from '~/typer/fritekstfeil';
+import {
+  IPostResponse,
+  RESPONSE_STATUS_FEIL,
+  RESPONSE_STATUS_OK,
+} from '~/typer/response';
+import { ETypografiTyper } from '~/typer/typografi';
+import {
+  i18nInnhold,
+  MAKS_INPUT_LENGDE,
+  validerTekst,
+} from '~/utils/fritekstfeltValidering';
+import { hentPathForSteg } from '~/utils/hentPathForSteg';
+
+import css from './../routes/send-endringsmelding.module.css';
+
+export async function action({ request }: ActionArgs) {
+  const formData = await request.formData();
+  const endringsmelding = formData.get('endringsmelding') as string;
+  return await sendEndringsmelding(
+    endringsmelding,
+    await getSession(request.headers.get('Cookie')),
+  ).then(response => {
+    if (response.ok) return response.json();
+    return { text: RESPONSE_STATUS_FEIL };
+  });
+}
+
+export default function SendEndringSide() {
+  const actionData: IPostResponse | undefined = useActionData<typeof action>();
+  const submit = useSubmit();
+
+  const tekster = useTekster(ESanityMappe.SEND_ENDRINGER);
+  const teksterFelles = useTekster(ESanityMappe.FELLES);
+  const navigate = useNavigate();
+  const [språk] = useSpråk();
+  const [, settEndringsmeldingMottattDato] = useEndringsmeldingMottattDato();
+
+  const [erResponseOK, settErResponseOK] = useState<boolean>(true);
+  const [valideringsfeil, settValideringsfeil] = useState<EFritekstFeil | null>(
+    EFritekstFeil.MANGLER_TEKST,
+  );
+  const [erKnappTrykketPå, settKnappTrykketPå] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!actionData) return;
+
+    if (actionData.text === RESPONSE_STATUS_OK && actionData.mottattDato) {
+      settEndringsmeldingMottattDato(actionData.mottattDato);
+      navigate(hentPathForSteg(ESteg.KVITTERING));
+    } else {
+      settErResponseOK(false);
+    }
+  }, [actionData, navigate, settEndringsmeldingMottattDato]);
+
+  function genererFeilmelding() {
+    return (
+      erKnappTrykketPå &&
+      valideringsfeil && (
+        <TekstBlokk
+          tekstblokk={tekster[fritekstFeilTilApiKeys[valideringsfeil]]}
+          typografi={ETypografiTyper.LABEL}
+        />
+      )
+    );
+  }
+
+  function håndterSendEndringsmelding(
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  ) {
+    event.preventDefault();
+    if (valideringsfeil === null) {
+      settErResponseOK(true);
+      submit(event.currentTarget, { replace: true });
+    }
+    settKnappTrykketPå(true);
+  }
+
+  return (
+    <HovedInnhold>
+      <StegIndikator nåværendeSteg={1} />
+      <TekstBlokk
+        tekstblokk={tekster.overskrift}
+        typografi={ETypografiTyper.STEG_HEADING_SMALL_H1}
+        dataTestid="overskriftSteg1"
+      />
+      <VeilederPanel innhold={tekster.veilederInnhold} />
+      <Form method="post" className={`${css.fullBredde}`}>
+        <Textarea
+          data-testid="fritekstfelt"
+          name="endringsmelding"
+          label={
+            <TekstBlokk
+              tekstblokk={tekster.fritekstfeltTittel}
+              dataTestid="fritekstfeltTittel"
+            />
+          }
+          description={
+            <TekstBlokk tekstblokk={tekster.fritekstfeltBeskrivelse} />
+          }
+          autoComplete="on"
+          maxLength={MAKS_INPUT_LENGDE}
+          i18n={i18nInnhold(språk)}
+          error={genererFeilmelding()}
+          onInput={event => {
+            settValideringsfeil(validerTekst(event.currentTarget.value));
+          }}
+        />
+        {!erResponseOK && (
+          <Alert variant="error" className={`${css.toppMargin}`}>
+            <TekstBlokk
+              tekstblokk={tekster.alertFeilUnderSendEndringsmelding}
+            />
+          </Alert>
+        )}
+        <div className={`${css.navigeringsKnappKonteiner}`}>
+          <Button
+            type="button"
+            variant={'secondary'}
+            onClick={() => navigate(hentPathForSteg(ESteg.FORSIDE))}
+          >
+            <TekstBlokk tekstblokk={teksterFelles.knappTilbake} />
+          </Button>
+          <Button
+            type="submit"
+            variant={valideringsfeil === null ? 'primary' : 'secondary'}
+            data-testid="knappVidereSteg1"
+            onClick={event => {
+              håndterSendEndringsmelding(event);
+            }}
+          >
+            <TekstBlokk tekstblokk={teksterFelles.knappSendEndringer} />
+          </Button>
+        </div>
+      </Form>
+    </HovedInnhold>
+  );
+}


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

Alle stønader skal ha en egen side for å sende endringer. 
Derfor er det gunstig å ha det som et eget komponent. Denne PRen antar at alle sider skal ha likt innhold. Det vil si at alle send endring sider vil ha et tekstfelt. 

[Lenke til trello kort](https://trello.com/c/H0K9rFBN/124-egen-komponent-for-side-send-endring)

### Hvordan er det løst? 🧠

1. Laget ny mappe `.app/sider`
2. Flyttet all koden fra `send-endringsmelding.tsx` i den nye komponent fila: `SendEndring.tsx`
3. Action funksjonen må ligge i routes, så action ligger ved siden av komponentet, slik; 

```javascript

export async function action({ request }: ActionArgs) {
  const formData = await request.formData();
  const endringsmelding = formData.get('endringsmelding') as string;
  console.log(endringsmelding);
  return await sendEndringsmelding(
    endringsmelding,
    await getSession(request.headers.get('Cookie')),
  ).then(response => {
    if (response.ok) return response.json();
    return { text: RESPONSE_STATUS_FEIL };
  });
}


// SendEndingSide importerer action funksjonen fra denne filen. 
export default function SendEndringsmelding() {
  return <SendEndringSide />;
}

```

### Ekstra: Forbedringer og eventuelle nye PRer ☀️

- Stønad typen burde komme fra kontekst. 
    - Bruker per nå `useTekster()` for å hente tekstene => Alltid tekster fra barnetrygd
- Bug ved å refreshe kvitterings siden. Kanskje man skulle navigere til forsiden med en feilmelding (?) 
   - Feilen kommer fra at state blir nullstilt  og at man prøver å formatere datoen stringen når den er `NULL`:
![image](https://github.com/bekk/nav-familie-endringsmelding/assets/66110094/8fbac5e8-d406-4cc4-8d8c-0ccbcee4c55c)

- Forlag til korleis koden kan se ut når man skal ta hensyn til at ulike stønader tar inn ulike input fra brukerer.
  - For eksempel at barnetrygd har 3 tekstfelt. Da er det nyttig med gjenbrukbar kode. 
  - Sudo kode av forslaget:
```typescript
// Knappen for å gå videre er i SendEndringSide komponentet
<SendEndringSide stønad={“BA”}  erValidert={erFritekstValidert & erKommuneValgt}>
   // Legger inn input komponenter basert på hva som trengst 
   <FritekstFelt />
   <KommuneVelger />
<SendEndringSide/>

```


