### PR TITLE
FIkset stylingen på motatt boks på kvitteringside

### DIFF
--- a/app/komponenter/bekreftelsesboks/Bekreftelseboks.tsx
+++ b/app/komponenter/bekreftelsesboks/Bekreftelseboks.tsx
@@ -8,13 +8,14 @@ import { ESanityMappe } from '~/typer/felles';
 import { formaterDato } from '~/utils/formaterDato';
 
 import TekstBlokk from '../tekstblokk/TekstBlokk';
+import css from './bekreftelsesboks.module.css';
 
 const BekreftelseBoks = () => {
   const { bekreftelseBoksInnhold } = useTekster(ESanityMappe.KVITTERING);
   const [endringsmeldingMottattDato] = useEndringsmeldingMottattDato();
 
   return (
-    <Alert variant="success">
+    <Alert variant="success" className={`${css.fullBredde}`}>
       <TekstBlokk
         tekstblokk={bekreftelseBoksInnhold}
         flettefelter={{ innsendtTid: formaterDato(endringsmeldingMottattDato) }}

--- a/app/komponenter/bekreftelsesboks/bekreftelsesboks.module.css
+++ b/app/komponenter/bekreftelsesboks/bekreftelsesboks.module.css
@@ -1,0 +1,3 @@
+.fullBredde {
+  width: 100%;
+}


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
Bekreftelses boksen på kvitteringsiden var kortere enn de andre komponentene og vi ville ha den til samme bredde 

[Lenke til trello kort](https://trello.com/c/ZzKT1CeQ/136-fikse-styling-på-mottatt-boks-på-kvitteringssiden)

### Hvordan er det løst? 🧠
Lage en css fil for Bekreftelsesboks og satt der bredden til å være 100% bredden var ikke det før, men nå ble den like stor som elementet under den 

<img width="680" alt="Screenshot 2023-07-17 at 14 43 08" src="https://github.com/bekk/nav-familie-endringsmelding/assets/31205453/60e0e2cd-0668-4881-ad25-8b83d0e30363">


