### PR TITLE
Flettefelt dato

### DIFF
--- a/app/komponenter/bekreftelsesboks/Bekreftelseboks.tsx
+++ b/app/komponenter/bekreftelsesboks/Bekreftelseboks.tsx
@@ -17,7 +17,7 @@ const BekreftelseBoks = () => {
     <Alert variant="success">
       <TekstBlokk
         tekstblokk={bekreftelseBoksInnhold}
-        flettefelter={{ mottattdato: formaterDato(endringsmeldingMottattDato) }}
+        flettefelter={{ mottattDato: formaterDato(endringsmeldingMottattDato) }}
       />
     </Alert>
   );

--- a/app/komponenter/bekreftelsesboks/Bekreftelseboks.tsx
+++ b/app/komponenter/bekreftelsesboks/Bekreftelseboks.tsx
@@ -17,7 +17,7 @@ const BekreftelseBoks = () => {
     <Alert variant="success">
       <TekstBlokk
         tekstblokk={bekreftelseBoksInnhold}
-        flettefelter={{ innsendtTid: formaterDato(endringsmeldingMottattDato) }}
+        flettefelter={{ mottattdato: formaterDato(endringsmeldingMottattDato) }}
       />
     </Alert>
   );

--- a/app/typer/sanity/sanity.ts
+++ b/app/typer/sanity/sanity.ts
@@ -25,7 +25,7 @@ export interface ISanityDokument {
 
 export enum ESanityFlettefeltverdi {
   SØKER_NAVN = 'SØKER_NAVN',
-  mottatt_dato = 'MOTTATT_DATO',
+  MOTTATT_DATO = 'MOTTATT_DATO',
 }
 
 export type FlettefeltVerdier = {

--- a/app/typer/sanity/sanity.ts
+++ b/app/typer/sanity/sanity.ts
@@ -25,12 +25,12 @@ export interface ISanityDokument {
 
 export enum ESanityFlettefeltverdi {
   SØKER_NAVN = 'SØKER_NAVN',
-  INNSENDT_TID = 'INNSENDT_TID',
+  mottatt_dato = 'MOTTATT_DATO',
 }
 
 export type FlettefeltVerdier = {
   søkerNavn?: string;
-  innsendtTid?: string;
+  mottattdato?: string;
 };
 
 export interface ITekstinnhold {

--- a/app/typer/sanity/sanity.ts
+++ b/app/typer/sanity/sanity.ts
@@ -30,7 +30,7 @@ export enum ESanityFlettefeltverdi {
 
 export type FlettefeltVerdier = {
   søkerNavn?: string;
-  mottattdato?: string;
+  mottattDato?: string;
 };
 
 export interface ITekstinnhold {

--- a/app/utils/fletteTilTekst.ts
+++ b/app/utils/fletteTilTekst.ts
@@ -13,10 +13,10 @@ export const flettefeltTilTekst = (
         throw Error('Flettefeltet søkernavn ikke sendt med');
       }
       return flettefelter.søkerNavn;
-    case ESanityFlettefeltverdi.INNSENDT_TID:
-      if (!flettefelter?.innsendtTid) {
+    case ESanityFlettefeltverdi.mottatt_dato:
+      if (!flettefelter?.mottattdato) {
         throw Error('Flettefeltet innsendt tid ikke sendt med');
       }
-      return flettefelter.innsendtTid;
+      return flettefelter.mottattdato;
   }
 };

--- a/app/utils/fletteTilTekst.ts
+++ b/app/utils/fletteTilTekst.ts
@@ -13,7 +13,7 @@ export const flettefeltTilTekst = (
         throw Error('Flettefeltet søkernavn ikke sendt med');
       }
       return flettefelter.søkerNavn;
-    case ESanityFlettefeltverdi.mottatt_dato:
+    case ESanityFlettefeltverdi.MOTTATT_DATO:
       if (!flettefelter?.mottattdato) {
         throw Error('Flettefeltet innsendt tid ikke sendt med');
       }

--- a/app/utils/fletteTilTekst.ts
+++ b/app/utils/fletteTilTekst.ts
@@ -14,9 +14,9 @@ export const flettefeltTilTekst = (
       }
       return flettefelter.søkerNavn;
     case ESanityFlettefeltverdi.MOTTATT_DATO:
-      if (!flettefelter?.mottattdato) {
+      if (!flettefelter?.mottattDato) {
         throw Error('Flettefeltet innsendt tid ikke sendt med');
       }
-      return flettefelter.mottattdato;
+      return flettefelter.mottattDato;
   }
 };


### PR DESCRIPTION
Hvorfor er dette nødvendig? ✨

I api-et så heter det mottatt dato mens i sanity heter den innsendt tid i kodebasen varierer det derfor hva det heter om det er i api-et eller sanity
[Lenke til trello kort](https://trello.com/c/RndHBVlV/116-navnebestemmelse-for-flettefelt-dato)

Hvordan er det løst? 🧠

Vi har satt ett navn på tidsobjektet for å skape mindre forvirring. Så det heter nå mottatt dato, endret navnet fra innsendt tid til mottatt dato. Denne endringen er det samme som skjer i endringsmelding-sanity, så denne og endringsmelding-sanity repoet er koblet sammen

<img width="653" alt="Screenshot 2023-07-18 at 09 47 01" src="https://github.com/bekk/nav-familie-endringsmelding/assets/31205453/8dcbe586-a38b-46c6-a167-6b24d3ff610e">

