### PR TITLE
Sett Prod miljø som default og legg opp til et Mock miljø

### DIFF
--- a/app/server/authorization.ts
+++ b/app/server/authorization.ts
@@ -65,6 +65,7 @@ const hentApiUrl = () => {
   switch (process.env.ENV) {
     case EMiljø.LOKAL:
       return 'http://localhost:8099';
+    case EMiljø.MOCK:
     case EMiljø.PRODUKSJON:
     default:
       return 'https://nav-familie-endringsmelding-api.fly.dev';

--- a/app/server/hentSøker.server.ts
+++ b/app/server/hentSøker.server.ts
@@ -1,5 +1,6 @@
 import { Session } from '@remix-run/node';
 
+import søkerMock from '~/mock/søkerMock';
 import { fetchMedToken } from '~/server/authorization';
 import { EMiljø } from '~/typer/miljø';
 import { ISøker } from '~/typer/søker';
@@ -13,6 +14,8 @@ export const hentSøker = async (session: Session): Promise<ISøker> => {
   switch (process.env.ENV) {
     case EMiljø.LOKAL:
       return (await fetchMedToken(session, LOKAL_URL_BACKEND)).json();
+    case EMiljø.MOCK:
+      return søkerMock;
     case EMiljø.PRODUKSJON:
     default:
       return (await fetchMedToken(session, API_URL_BACKEND)).json();

--- a/app/server/sendEndringsmelding.server.ts
+++ b/app/server/sendEndringsmelding.server.ts
@@ -30,14 +30,15 @@ export async function sendEndringsmelding(
         requestInfo,
         JSON.stringify(endringsmelding),
       );
+    case EMiljø.MOCK:
+      return json(postResponseMock);
     case EMiljø.PRODUKSJON:
+    default:
       return await postMedToken(
         session,
         API_URL_BACKEND,
         requestInfo,
         JSON.stringify(endringsmelding),
       );
-    default:
-      return json(postResponseMock);
   }
 }

--- a/app/typer/miljø.ts
+++ b/app/typer/miljø.ts
@@ -1,4 +1,5 @@
 export enum EMiljø {
   PRODUKSJON = 'PRODUKSJON',
   LOKAL = 'LOKAL',
+  MOCK = 'MOCK',
 }


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

Ønsker at dersom ingen miljø er satt så bruker man prod URLer.
Det kan derfor og være fint å ha et miljø som mocker. 

I prod så blir ikkje endringsmeldingen faktisk sendt, men mocket!
Så denne PRen handler også om å fikse feil i Prod. 

[Lenke til trello kort](https://trello.com/c/XR3FdKhf/149-bruke-prod-linker-som-default)

### Hvordan er det løst? 🧠
Default caser i alle switch caser med `process.env.ENV` har nå default case til prod. 
La opp til Mocket miljø, men dette må settes i `.env` filen lokalt;

```env
ENV=MOCK
```

