### PR TITLE
Bump @remix pakker til 1.19.0 (Avhengig av hverandre)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,10 @@
         "@navikt/nav-dekoratoren-moduler": "^2.1.1",
         "@portabletext/react": "^3.0.2",
         "@portabletext/types": "^2.0.2",
-        "@remix-run/css-bundle": "^1.18.1",
-        "@remix-run/node": "^1.18.1",
+        "@remix-run/css-bundle": "^1.19.0",
+        "@remix-run/node": "^1.19.0",
         "@remix-run/react": "^1.18.1",
-        "@remix-run/serve": "^1.18.1",
+        "@remix-run/serve": "^1.19.0",
         "@sanity/client": "^6.1.3",
         "cookie": "^0.5.0",
         "eslint-plugin-simple-import-sort": "^10.00.0",
@@ -29,7 +29,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@remix-run/dev": "^1.18.1",
+        "@remix-run/dev": "^1.19.0",
         "@remix-run/eslint-config": "^1.18.1",
         "@types/cookie": "^0.5.1",
         "@types/react": "^18.0.35",
@@ -3131,17 +3131,17 @@
       }
     },
     "node_modules/@remix-run/css-bundle": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/css-bundle/-/css-bundle-1.18.1.tgz",
-      "integrity": "sha512-j6CflpY3fmMb1chZLBvNPifLmAVWexXJ+tiiZKwXC/eVIrbKADlQCsWmTdYPjsMP+OkZja7TGdSivqQOjCAu0Q==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/css-bundle/-/css-bundle-1.19.0.tgz",
+      "integrity": "sha512-d7qn73AQxsFB/jg92BVZ9FrLiVnIlmzEuyNhffTK3XQg0up75I71I4vtGTcBBR3SPNVzv3+EFxpcsLh45b7TZA==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@remix-run/dev": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-1.18.1.tgz",
-      "integrity": "sha512-uT+YRGiR17p51y284MvEZMpkFkIykJ0uTVP3hepW0fvtoD+dt09DFVk1AQkJhEKlIVECkyR9lrOtceP/2qML6w==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-1.19.0.tgz",
+      "integrity": "sha512-DcBPKDaAoOnQoMT0IeKZ0XklLOYuoL5XHsWXoS/p1mIzpECq4elv7pPM9SzYVjHoVeGM4ih8ncB2KtfJrqM7ag==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.21.8",
@@ -3154,7 +3154,7 @@
         "@babel/traverse": "^7.21.5",
         "@babel/types": "^7.21.5",
         "@npmcli/package-json": "^2.0.0",
-        "@remix-run/server-runtime": "1.18.1",
+        "@remix-run/server-runtime": "1.19.0",
         "@vanilla-extract/integration": "^6.2.0",
         "arg": "^5.0.1",
         "cacache": "^15.0.5",
@@ -3162,7 +3162,7 @@
         "chokidar": "^3.5.1",
         "dotenv": "^16.0.0",
         "esbuild": "0.17.6",
-        "esbuild-plugins-node-modules-polyfill": "^1.0.16",
+        "esbuild-plugins-node-modules-polyfill": "^1.3.0",
         "execa": "5.1.1",
         "exit-hook": "2.2.1",
         "express": "^4.17.1",
@@ -3206,7 +3206,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@remix-run/serve": "^1.18.1"
+        "@remix-run/serve": "^1.19.0"
       },
       "peerDependenciesMeta": {
         "@remix-run/serve": {
@@ -3267,11 +3267,11 @@
       }
     },
     "node_modules/@remix-run/express": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-1.18.1.tgz",
-      "integrity": "sha512-jI751cvY2pi4ZD7/+5qAC1Xyt049EM3baNhm5VATsVaTNVOJbNxazOvKflv+bLbpw1lV9sF3MAAMnig5YqStMg==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-1.19.0.tgz",
+      "integrity": "sha512-wPDKKJiwYosC8rOHrq0ONe3qKLnmy56osFoD04Y+WCPzua6LkpatLvymzlO+4j1Xwe7szMrDbUBsSHo7ZknCkg==",
       "dependencies": {
-        "@remix-run/node": "1.18.1"
+        "@remix-run/node": "1.19.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3281,12 +3281,12 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.18.1.tgz",
-      "integrity": "sha512-Civ8hQGdQKxmYtDvzV+8sYOPiLfH2FtT35iSwEqDN49uraInljoWngSwzrRmKkilhI4eABSN9fv0trUDyOTBrQ==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.19.0.tgz",
+      "integrity": "sha512-gL0IBjcblddC85tQ5r7VHtS/oOVoWOoso+ZCC/G0SzZO/wEiq3bpi9c6UA1/bI1a9Kvgr+wKclWl9XwpWCGwvQ==",
       "dependencies": {
-        "@remix-run/server-runtime": "1.18.1",
-        "@remix-run/web-fetch": "^4.3.4",
+        "@remix-run/server-runtime": "1.19.0",
+        "@remix-run/web-fetch": "^4.3.5",
         "@remix-run/web-file": "^3.0.2",
         "@remix-run/web-stream": "^1.0.3",
         "@web3-storage/multipart-parser": "^1.0.0",
@@ -3324,12 +3324,12 @@
       }
     },
     "node_modules/@remix-run/serve": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-1.18.1.tgz",
-      "integrity": "sha512-u3SFXjUYmm3RV02QMGfCrjw7qMxg7y3wpnDf9RWfZtZG6oQEHpGkJeUXdSJjVGCmGQlWtGoVaFZ0fOQllu9G4g==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-1.19.0.tgz",
+      "integrity": "sha512-OK3U4p/jSE5tOiyC+mSZGWU1fTMhUHiVNElr1mEhgLcMyLHaorenz9cY7ybInfVnpfBcWOmOeWWCJHLfcVjYJg==",
       "dependencies": {
-        "@remix-run/express": "1.18.1",
-        "@remix-run/node": "1.18.1",
+        "@remix-run/express": "1.19.0",
+        "@remix-run/node": "1.19.0",
         "compression": "^1.7.4",
         "express": "^4.17.1",
         "morgan": "^1.10.0"
@@ -3342,11 +3342,11 @@
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.18.1.tgz",
-      "integrity": "sha512-E0sQlgUQG2ytFmUH7zRH7n2MufnP6WWWq1KpRoiuwJZxfTFIzaiCCIiNqbP/uXGWDGcwEevpawNUzzszL1tT0w==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.19.0.tgz",
+      "integrity": "sha512-Qwo/7omjLxbBB7nnzzgWd/PAScMjLEjNCeBkOw9qdgAubPSGqGakqG4w036fwQ3rXB5OlHsTOZI4Hxoh4AJHSg==",
       "dependencies": {
-        "@remix-run/router": "1.7.1",
+        "@remix-run/router": "1.7.2",
         "@types/cookie": "^0.4.1",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.4.1",
@@ -3355,6 +3355,14 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@remix-run/server-runtime/node_modules/@remix-run/router": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.7.2.tgz",
+      "integrity": "sha512-7Lcn7IqGMV+vizMPoEl5F0XDshcdDYtMI6uJLQdQz5CfZAwy3vvGKYSUk789qndt5dEC4HfSjviSYlSoHGL2+A==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@remix-run/server-runtime/node_modules/@types/cookie": {
@@ -3380,9 +3388,9 @@
       }
     },
     "node_modules/@remix-run/web-fetch": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.3.4.tgz",
-      "integrity": "sha512-AUM1XBa4hcgeNt2CD86OlB5aDLlqdMl0uJ+89R8dPGx07I5BwMXnbopCaPAkvSBIoHeT/IoLWIuZrLi7RvXS+Q==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.3.5.tgz",
+      "integrity": "sha512-cLLeNLvLRyFRhJLulzS98bb07kJ+ENkGaqUkBisdG4FNEoZF6tXtrTGLWJNJa1nAP/wFkMKEDxIP77LgAPyeow==",
       "dependencies": {
         "@remix-run/web-blob": "^3.0.4",
         "@remix-run/web-form-data": "^3.0.3",
@@ -6433,9 +6441,9 @@
       }
     },
     "node_modules/esbuild-plugins-node-modules-polyfill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/esbuild-plugins-node-modules-polyfill/-/esbuild-plugins-node-modules-polyfill-1.2.0.tgz",
-      "integrity": "sha512-jWyCoWQKRbxUUfWLO900IyBDHihavTMbQLCDRq8xqj6NhQ75eW7YRvdraSDzFqQ6/eLnhNZlvantQtYbZjqU0A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/esbuild-plugins-node-modules-polyfill/-/esbuild-plugins-node-modules-polyfill-1.3.0.tgz",
+      "integrity": "sha512-r/aNOvAlIaIzqJwvFHWhDGrPF/Aj5qI1zKVeHbCFpKH+bnKW1BG2LGixMd3s6hyWcZHcfdl2QZRucVuOLzFRrA==",
       "dev": true,
       "dependencies": {
         "@jspm/core": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@portabletext/types": "^2.0.2",
         "@remix-run/css-bundle": "^1.19.0",
         "@remix-run/node": "^1.19.0",
-        "@remix-run/react": "^1.18.1",
+        "@remix-run/react": "^1.19.0",
         "@remix-run/serve": "^1.19.0",
         "@sanity/client": "^6.1.3",
         "cookie": "^0.5.0",
@@ -3300,12 +3300,12 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.18.1.tgz",
-      "integrity": "sha512-vs94AxXXaXU0K3W4zQ05hR9R1+Ief9oq5JZOZKdeFoM2dgdSb6u/ovRNyQK1ukzjIBO9vARpNC0HMeqN/eGhtw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.19.0.tgz",
+      "integrity": "sha512-wZBNfA+wtX4GQ2xQyWefSpq45b9b+DydXq+mucog1jaR2OPFmSDjNzwp09Nc8G1TcpsvDH4CNgz4nsA94WvFmQ==",
       "dependencies": {
-        "@remix-run/router": "1.7.1",
-        "react-router-dom": "6.14.1"
+        "@remix-run/router": "1.7.2",
+        "react-router-dom": "6.14.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3316,9 +3316,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.7.1.tgz",
-      "integrity": "sha512-bgVQM4ZJ2u2CM8k1ey70o1ePFXsEzYVZoWghh6WjM8p59jQ7HxzbHW4SbnWFG7V9ig9chLawQxDTZ3xzOF8MkQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.7.2.tgz",
+      "integrity": "sha512-7Lcn7IqGMV+vizMPoEl5F0XDshcdDYtMI6uJLQdQz5CfZAwy3vvGKYSUk789qndt5dEC4HfSjviSYlSoHGL2+A==",
       "engines": {
         "node": ">=14"
       }
@@ -3355,14 +3355,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@remix-run/server-runtime/node_modules/@remix-run/router": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.7.2.tgz",
-      "integrity": "sha512-7Lcn7IqGMV+vizMPoEl5F0XDshcdDYtMI6uJLQdQz5CfZAwy3vvGKYSUk789qndt5dEC4HfSjviSYlSoHGL2+A==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@remix-run/server-runtime/node_modules/@types/cookie": {
@@ -12917,11 +12909,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.14.1.tgz",
-      "integrity": "sha512-U4PfgvG55LdvbQjg5Y9QRWyVxIdO1LlpYT7x+tMAxd9/vmiPuJhIwdxZuIQLN/9e3O4KFDHYfR9gzGeYMasW8g==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.14.2.tgz",
+      "integrity": "sha512-09Zss2dE2z+T1D03IheqAFtK4UzQyX8nFPWx6jkwdYzGLXd5ie06A6ezS2fO6zJfEb/SpG6UocN2O1hfD+2urQ==",
       "dependencies": {
-        "@remix-run/router": "1.7.1"
+        "@remix-run/router": "1.7.2"
       },
       "engines": {
         "node": ">=14"
@@ -12931,12 +12923,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.14.1.tgz",
-      "integrity": "sha512-ssF6M5UkQjHK70fgukCJyjlda0Dgono2QGwqGvuk7D+EDGHdacEN3Yke2LTMjkrpHuFwBfDFsEjGVXBDmL+bWw==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.14.2.tgz",
+      "integrity": "sha512-5pWX0jdKR48XFZBuJqHosX3AAHjRAzygouMTyimnBPOLdY3WjzUSKhus2FVMihUFWzeLebDgr4r8UeQFAct7Bg==",
       "dependencies": {
-        "@remix-run/router": "1.7.1",
-        "react-router": "6.14.1"
+        "@remix-run/router": "1.7.2",
+        "react-router": "6.14.2"
       },
       "engines": {
         "node": ">=14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
       },
       "devDependencies": {
         "@remix-run/dev": "^1.19.0",
-        "@remix-run/eslint-config": "^1.18.1",
+        "@remix-run/eslint-config": "^1.19.0",
         "@types/cookie": "^0.5.1",
         "@types/react": "^18.0.35",
         "@types/react-dom": "^18.0.11",
@@ -3230,9 +3230,9 @@
       }
     },
     "node_modules/@remix-run/eslint-config": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-1.18.1.tgz",
-      "integrity": "sha512-r0vjv+//isRseRShZ6RbX2bJSjQzfE7R2KOf4v1v+EVQZ59Vk0cR6UPwlxHN4Wc3jtTa2yBlLCm1H24ImKLQ4Q==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-1.19.0.tgz",
+      "integrity": "sha512-pfGJnZ+Fv5+e/kF67K00dj1AA7okcsiUf/PqPwRr66mgGEe9CeLJQ5IZcczQx6TmIi574yy1G5sblz5L9EGlUg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.21.8",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "@navikt/nav-dekoratoren-moduler": "^2.1.1",
     "@portabletext/react": "^3.0.2",
     "@portabletext/types": "^2.0.2",
-    "@remix-run/css-bundle": "^1.18.1",
-    "@remix-run/node": "^1.18.1",
+    "@remix-run/css-bundle": "^1.19.0",
+    "@remix-run/node": "^1.19.0",
     "@remix-run/react": "^1.18.1",
-    "@remix-run/serve": "^1.18.1",
+    "@remix-run/serve": "^1.19.0",
     "@sanity/client": "^6.1.3",
     "cookie": "^0.5.0",
     "eslint-plugin-simple-import-sort": "^10.00.0",
@@ -42,7 +42,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@remix-run/dev": "^1.18.1",
+    "@remix-run/dev": "^1.19.0",
     "@remix-run/eslint-config": "^1.18.1",
     "@types/cookie": "^0.5.1",
     "@types/react": "^18.0.35",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@portabletext/types": "^2.0.2",
     "@remix-run/css-bundle": "^1.19.0",
     "@remix-run/node": "^1.19.0",
-    "@remix-run/react": "^1.18.1",
+    "@remix-run/react": "^1.19.0",
     "@remix-run/serve": "^1.19.0",
     "@sanity/client": "^6.1.3",
     "cookie": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@remix-run/dev": "^1.19.0",
-    "@remix-run/eslint-config": "^1.18.1",
+    "@remix-run/eslint-config": "^1.19.0",
     "@types/cookie": "^0.5.1",
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

Fire nye PRer på bakkebump for @remix;  #98, #99, #100 og #101 
Alle pakene går fra versjon 1.18.1 til 1.19.0. Pakkene er også avhengige og kan ikkje løses kvar for seg. 
Dependabot klarer det ikkje; 

![image](https://github.com/bekk/nav-familie-endringsmelding/assets/66110094/fbcc2cf4-5723-4f05-9a8d-3c64befb8a69)


Alle pakkene handler om å legge til en feature; 

> When building for non-Node.js server platforms, you can now control which polyfills are included (or disbale them entirely) by setting serverNodeBuiltinsPolyfill in remix.config.js ([#6814](https://redirect.github.com/remix-run/remix/pull/6814), [#6859](https://redirect.github.com/remix-run/remix/pull/6859), [#6877](https://redirect.github.com/remix-run/remix/pull/6877)).

Følgende pakker skal bumpes: 

```json
"@remix-run/css-bundle": "^1.19.0",
"@remix-run/node": "^1.19.0",
"@remix-run/serve": "^1.19.0",
"@remix-run/dev": "^1.19.0",

```

### Hvordan er det løst? 🧠

Bumper pakker manuelt 💻 

**NB!** Måtte bumpe @remix-run/react til 1.19.0 for at det skulle passe

### Ekstra: Remix Release notes for 1.19.0

Les mer om remix 1.19.0 her; 
https://github.com/remix-run/remix/releases/tag/remix%401.19.0
