### PR TITLE
Legg til side for dokumentasjonsopplastning

### DIFF
--- a/app/komponenter/stegindikator/StegIndikator.tsx
+++ b/app/komponenter/stegindikator/StegIndikator.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const StegIndikator: React.FC<Props> = ({ nåværendeSteg }) => {
-  const ANTALL_STEG = 2;
+  const ANTALL_STEG = 3;
   const sisteSteg = nåværendeSteg === ANTALL_STEG;
 
   return (

--- a/app/routes/ba.dokumentasjon.tsx
+++ b/app/routes/ba.dokumentasjon.tsx
@@ -1,0 +1,5 @@
+import DokumentasjonSide from '~/sider/Dokumentasjon';
+
+export default function BADokumentasjon() {
+  return <DokumentasjonSide />;
+}

--- a/app/routes/ks.dokumentasjon.tsx
+++ b/app/routes/ks.dokumentasjon.tsx
@@ -1,0 +1,5 @@
+import DokumentasjonSide from '~/sider/Dokumentasjon';
+
+export default function KSDokumentasjon() {
+  return <DokumentasjonSide />;
+}

--- a/app/sider/Dokumentasjon.tsx
+++ b/app/sider/Dokumentasjon.tsx
@@ -1,0 +1,11 @@
+import HovedInnhold from '~/komponenter/hovedInnhold/HovedInnhold';
+import StegIndikator from '~/komponenter/stegindikator/StegIndikator';
+
+export default function DokumentasjonSide() {
+  return (
+    <HovedInnhold /*måHaBekreftetSamtykke*/>
+      <StegIndikator nåværendeSteg={2} />
+      <h1>Dokumentasjonsopplastning her</h1>
+    </HovedInnhold>
+  );
+}

--- a/app/sider/kvitteringSide.tsx
+++ b/app/sider/kvitteringSide.tsx
@@ -12,7 +12,7 @@ export default function KvitteringSide() {
 
   return (
     <HovedInnhold måHaBekreftetSamtykke>
-      <StegIndikator nåværendeSteg={2} />
+      <StegIndikator nåværendeSteg={3} />
       <TekstBlokk
         tekstblokk={tekster.kvitteringTittel}
         typografi={ETypografiTyper.STEG_HEADING_SMALL_H1}

--- a/cypress/e2e/steg1.cy.ts
+++ b/cypress/e2e/steg1.cy.ts
@@ -14,7 +14,7 @@ describe('Steg1-test', () => {
     );
   });
   it('Sjekker at stegindikator har rett antall steg', () => {
-    cy.get('.navds-stepper').children().should('have.length', 2);
+    cy.get('.navds-stepper').children().should('have.length', 3);
   });
   //TODO: finne en måte å teste at rett steg på stegIndikator er aktivt. Prøvd metoder liknende denne, uten hell:
   /*   it('Sjekker at stegindikator har attributt activeStep, () => {


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

For å legge til et steg for dokumentasjonsopplastning, må dvi starte med en side.
[Lenke til trello kort](https://trello.com/c/oahVlJsJ/137-steg-for-dokumentasjonsopplastning)

<img width="1489" alt="image" src="https://github.com/bekk/nav-familie-endringsmelding/assets/69514415/86ca48e7-9f65-45e4-b91f-4228975778bb">


### Hvordan er det løst? 🧠
Har lagt til en route for dokumentasjonsopplastning både i ks og ba, som begge kaller på side-komponenten `DokumentasjonSide`. Per nå inneholder denne kun en overskrift og stegindikator, for å enkelt kunne bygge videre.

Stegindikatoren er for øvrig oppdatert med korrekt antall steg.