### PR TITLE
Vis spinner ved sending av endringsmelding

### DIFF
--- a/app/sider/SendEndring.tsx
+++ b/app/sider/SendEndring.tsx
@@ -148,7 +148,7 @@ export default function SendEndringSide() {
                 <TekstBlokk tekstblokk={teksterFelles.knappSendEndringer} />
               </Button>
             </div>
-          </Form>{' '}
+          </Form>
         </>
       )}
     </HovedInnhold>

--- a/app/sider/SendEndring.tsx
+++ b/app/sider/SendEndring.tsx
@@ -90,7 +90,7 @@ export default function SendEndringSide() {
 
   return (
     <HovedInnhold måHaBekreftetSamtykke>
-      {navigation.state === 'submitting' ? (
+      {navigation.state === 'submitting' || navigation.state === 'loading' ? (
         <Spinner />
       ) : (
         <>

--- a/app/sider/SendEndring.tsx
+++ b/app/sider/SendEndring.tsx
@@ -1,5 +1,11 @@
 import { Alert, Button, Textarea } from '@navikt/ds-react';
-import { Form, useActionData, useNavigate, useSubmit } from '@remix-run/react';
+import {
+  Form,
+  useActionData,
+  useNavigate,
+  useNavigation,
+  useSubmit,
+} from '@remix-run/react';
 import React, { useEffect, useState } from 'react';
 
 import {
@@ -9,6 +15,7 @@ import {
   useYtelse,
 } from '~/hooks/contextHooks';
 import HovedInnhold from '~/komponenter/hovedInnhold/HovedInnhold';
+import Spinner from '~/komponenter/Spinner';
 import StegIndikator from '~/komponenter/stegindikator/StegIndikator';
 import TekstBlokk from '~/komponenter/tekstblokk/TekstBlokk';
 import VeilederPanel from '~/komponenter/veilederpanel/VeilederPanel';
@@ -37,6 +44,7 @@ export default function SendEndringSide() {
   const tekster = useTekster(ESanityMappe.SEND_ENDRINGER);
   const teksterFelles = useTekster(ESanityMappe.FELLES);
   const navigate = useNavigate();
+  const navigation = useNavigation();
   const [språk] = useSpråk();
   const [, settEndringsmeldingMottattDato] = useEndringsmeldingMottattDato();
 
@@ -82,61 +90,67 @@ export default function SendEndringSide() {
 
   return (
     <HovedInnhold måHaBekreftetSamtykke>
-      <StegIndikator nåværendeSteg={1} />
-      <TekstBlokk
-        tekstblokk={tekster.overskrift}
-        typografi={ETypografiTyper.STEG_HEADING_SMALL_H1}
-        dataTestid="overskriftSteg1"
-      />
-      <VeilederPanel innhold={tekster.veilederInnhold} />
-      <Form method="post" className={`${css.fullBredde}`}>
-        <Textarea
-          data-testid="fritekstfelt"
-          name="endringsmelding"
-          label={
-            <TekstBlokk
-              tekstblokk={tekster.fritekstfeltTittel}
-              dataTestid="fritekstfeltTittel"
+      {navigation.state === 'submitting' ? (
+        <Spinner />
+      ) : (
+        <>
+          <StegIndikator nåværendeSteg={1} />
+          <TekstBlokk
+            tekstblokk={tekster.overskrift}
+            typografi={ETypografiTyper.STEG_HEADING_SMALL_H1}
+            dataTestid="overskriftSteg1"
+          />
+          <VeilederPanel innhold={tekster.veilederInnhold} />
+          <Form method="post" className={`${css.fullBredde}`}>
+            <Textarea
+              data-testid="fritekstfelt"
+              name="endringsmelding"
+              label={
+                <TekstBlokk
+                  tekstblokk={tekster.fritekstfeltTittel}
+                  dataTestid="fritekstfeltTittel"
+                />
+              }
+              description={
+                <TekstBlokk tekstblokk={tekster.fritekstfeltBeskrivelse} />
+              }
+              autoComplete="on"
+              maxLength={MAKS_INPUT_LENGDE}
+              i18n={i18nInnhold(språk)}
+              error={genererFeilmelding()}
+              onInput={event => {
+                settValideringsfeil(validerTekst(event.currentTarget.value));
+              }}
             />
-          }
-          description={
-            <TekstBlokk tekstblokk={tekster.fritekstfeltBeskrivelse} />
-          }
-          autoComplete="on"
-          maxLength={MAKS_INPUT_LENGDE}
-          i18n={i18nInnhold(språk)}
-          error={genererFeilmelding()}
-          onInput={event => {
-            settValideringsfeil(validerTekst(event.currentTarget.value));
-          }}
-        />
-        {!erResponseOK && (
-          <Alert variant="error" className={`${css.toppMargin}`}>
-            <TekstBlokk
-              tekstblokk={tekster.alertFeilUnderSendEndringsmelding}
-            />
-          </Alert>
-        )}
-        <div className={`${css.navigeringsKnappKonteiner}`}>
-          <Button
-            type="button"
-            variant={'secondary'}
-            onClick={() => navigate(hentPathForSteg(ytelse, ESteg.FORSIDE))}
-          >
-            <TekstBlokk tekstblokk={teksterFelles.knappTilbake} />
-          </Button>
-          <Button
-            type="submit"
-            variant={valideringsfeil === null ? 'primary' : 'secondary'}
-            data-testid="knappVidereSteg1"
-            onClick={event => {
-              håndterSendEndringsmelding(event);
-            }}
-          >
-            <TekstBlokk tekstblokk={teksterFelles.knappSendEndringer} />
-          </Button>
-        </div>
-      </Form>
+            {!erResponseOK && (
+              <Alert variant="error" className={`${css.toppMargin}`}>
+                <TekstBlokk
+                  tekstblokk={tekster.alertFeilUnderSendEndringsmelding}
+                />
+              </Alert>
+            )}
+            <div className={`${css.navigeringsKnappKonteiner}`}>
+              <Button
+                type="button"
+                variant={'secondary'}
+                onClick={() => navigate(hentPathForSteg(ytelse, ESteg.FORSIDE))}
+              >
+                <TekstBlokk tekstblokk={teksterFelles.knappTilbake} />
+              </Button>
+              <Button
+                type="submit"
+                variant={valideringsfeil === null ? 'primary' : 'secondary'}
+                data-testid="knappVidereSteg1"
+                onClick={event => {
+                  håndterSendEndringsmelding(event);
+                }}
+              >
+                <TekstBlokk tekstblokk={teksterFelles.knappSendEndringer} />
+              </Button>
+            </div>
+          </Form>{' '}
+        </>
+      )}
     </HovedInnhold>
   );
 }


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

Brukeren får ingen tilbakemelding etter at han har trykket på "send  endringsmelding". 

Mål: Vis spinner når brukeren har trykket på "send endringsmelding"

[Lenke til trello kort](https://trello.com/c/hYkAKuYA/112-vise-spinner-etter-trykket-p%C3%A5-send-inn)

### Hvordan er det løst? 🧠

Brukte `useNavigation()`. Dette er et react router hook som gir blandt annet state tilbake. Kan derfor vise spinner basert på state; 

```typescript
// Sudo kode for hvordan koden fungerer. 
{navigation.state === 'submitting' || navigation.state === 'loading' ? <Spinner/> ? <SendEndringSide/> }
```

**NB!** State er submitting når du gjør POST request til backend og state loading når du laster inn kvitterings siden. 

I demoen under bruker eg throttling for å "simulere" dårlig dekning eller treg prosess. 

https://github.com/bekk/nav-familie-endringsmelding/assets/66110094/8d3abfb4-7967-4868-b376-ef5d2d2229cc


### Ekstra

- Burde se på stylingen av spinneren: Sentrering og gi litt topp margin kanskje? 
   - Har ikkje laget kort på dette
- Burde lage kort på å få spinneren i bruk med `useNavigation` på alle andre sider som kan eller vil bruke tid på å laste

React Router dokumentasjon her, se på denne for å lære litt om den; 
https://reactrouter.com/en/6.14.2/hooks/use-navigation

Brukte også `useNavigation` fordi `useTransition` blir byttet ut i v2 av remix ;) 
