### PR TITLE
Sett språk i lang-attributtet ved endring

### DIFF
--- a/app/komponenter/språkvelger/språkvelger.tsx
+++ b/app/komponenter/språkvelger/språkvelger.tsx
@@ -19,6 +19,7 @@ export const Språkvelger = () => {
         autoComplete="on"
         onChange={endring => {
           settSpråk(endring.target.value as ELocaleType);
+          document.documentElement.lang = endring.target.value;
         }}
       >
         <option value={ELocaleType.NB}>Norsk (Bokmål)</option>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -72,7 +72,7 @@ export default function App() {
   const { dekoratørFragmenter } = useLoaderData<typeof loader>();
 
   return (
-    <Dokument språk={ELocaleType.NB}>
+    <Dokument>
       <Oppsett>
         <Outlet />
         <ScrollRestoration />
@@ -86,13 +86,12 @@ export default function App() {
 
 interface DokumentProps {
   children: React.ReactNode;
-  språk?: ELocaleType;
 }
 
-export function Dokument({ children, språk = ELocaleType.NB }: DokumentProps) {
+export function Dokument({ children }: DokumentProps) {
   const { dekoratørFragmenter } = useLoaderData<typeof loader>();
   return (
-    <html lang={språk}>
+    <html lang={ELocaleType.NB}>
       <head>
         <title>Endringsmelding</title>
         <meta charSet="utf-8" />


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
Når vi flyttet contexten fra `root.tsx` ble ikke lenger språket i HTML lang-attributet oppdatert når språket ble endret i språkvelgeren, noe det bør ref [Aksel](https://aksel.nav.no/god-praksis/artikler/utvikling): Bruk lang-attributtet på html-elementet for å sikre at skjermlesere leser opp innholdet med riktig stemme. 

[Lenke til trello kort](https://trello.com/c/70wF6AKO/143-uu-krav-spr%C3%A5k-m%C3%A5-bli-satt-html-taggen)

### Hvordan er det løst? 🧠
Med inspirasjon fra [ks](https://github.com/navikt/familie-ks-soknad/blob/69e40d535d9dfb8f80c10b1c0e693f1329397d29/src/frontend/components/Felleskomponenter/Dekorat%C3%B8ren/Dekorat%C3%B8renSpr%C3%A5kHandler.tsx#L12) settes språket ved bruk av `document.documentElement.lang` i `språkvelger.tsx`.