### PR TITLE
Legg til endepunkt for KS

### DIFF
--- a/app/routes/ba.endringsmelding.tsx
+++ b/app/routes/ba.endringsmelding.tsx
@@ -2,9 +2,10 @@ import { ActionArgs } from '@remix-run/node';
 
 import sendEndringAction from '~/server/sendEndringAction.server';
 import SendEndringSide from '~/sider/SendEndring';
+import { EYtelse } from '~/typer/ytelse';
 
 export async function action({ request }: ActionArgs) {
-  return sendEndringAction(request);
+  return sendEndringAction(request, EYtelse.BARNETRYGD);
 }
 
 export default function BAEndringsmelding() {

--- a/app/routes/ks.endringsmelding.tsx
+++ b/app/routes/ks.endringsmelding.tsx
@@ -2,9 +2,10 @@ import { ActionArgs } from '@remix-run/node';
 
 import sendEndringAction from '~/server/sendEndringAction.server';
 import SendEndringSide from '~/sider/SendEndring';
+import { EYtelse } from '~/typer/ytelse';
 
 export async function action({ request }: ActionArgs) {
-  return sendEndringAction(request);
+  return sendEndringAction(request, EYtelse.KONTANTSTØTTE);
 }
 
 export default function KSEndringsmelding() {

--- a/app/server/sendEndringAction.server.ts
+++ b/app/server/sendEndringAction.server.ts
@@ -2,16 +2,27 @@ import { sendEndringsmelding } from '~/server/sendEndringsmelding.server';
 import { getSession } from '~/sessions';
 import { IEndringsmelding } from '~/typer/endringsmelding';
 import { EStatusKode, IPostResponse } from '~/typer/response';
+import { EYtelse } from '~/typer/ytelse';
 
-export default async function sendEndringAction(request: Request) {
+export default async function sendEndringAction(
+  request: Request,
+  ytelse: EYtelse,
+) {
   const formData = await request.formData();
   const endringsmeldingTekst = formData.get('endringsmelding') as string;
   const endringsmelding: IEndringsmelding = {
     tekst: endringsmeldingTekst,
     dokumenter: [],
   };
+  let ytelseSti: string = '';
+  if (ytelse === EYtelse.BARNETRYGD) {
+    ytelseSti = 'ba';
+  } else if (ytelse === EYtelse.KONTANTSTØTTE) {
+    ytelseSti = 'ks';
+  }
   return await sendEndringsmelding(
     endringsmelding,
+    ytelseSti,
     await getSession(request.headers.get('Cookie')),
   )
     .then(async response => {

--- a/app/server/sendEndringAction.server.ts
+++ b/app/server/sendEndringAction.server.ts
@@ -3,6 +3,7 @@ import { getSession } from '~/sessions';
 import { IEndringsmelding } from '~/typer/endringsmelding';
 import { EStatusKode, IPostResponse } from '~/typer/response';
 import { EYtelse } from '~/typer/ytelse';
+import { hentAPIPathForYtelse } from '~/utils/hentPath';
 
 export default async function sendEndringAction(
   request: Request,
@@ -14,12 +15,7 @@ export default async function sendEndringAction(
     tekst: endringsmeldingTekst,
     dokumenter: [],
   };
-  let ytelseSti: string = '';
-  if (ytelse === EYtelse.BARNETRYGD) {
-    ytelseSti = 'ba';
-  } else if (ytelse === EYtelse.KONTANTSTØTTE) {
-    ytelseSti = 'ks';
-  }
+  const ytelseSti = hentAPIPathForYtelse(ytelse);
   return await sendEndringsmelding(
     endringsmelding,
     ytelseSti,

--- a/app/server/sendEndringsmelding.server.ts
+++ b/app/server/sendEndringsmelding.server.ts
@@ -6,15 +6,16 @@ import { EMiljø } from '~/typer/miljø';
 
 import { postMedToken } from './authorization';
 
-const STI: string = '/api/send-inn/ba';
-const LOKAL_URL_BACKEND: string = 'http://localhost:8099' + STI;
-const API_URL_BACKEND: string =
-  'https://nav-familie-endringsmelding-api.fly.dev' + STI;
-
 export async function sendEndringsmelding(
   endringsmelding: IEndringsmelding,
+  ytelseSti: string,
   session: Session,
 ): Promise<Response> {
+  const STI: string = '/api/send-inn/' + ytelseSti;
+  const LOKAL_URL_BACKEND: string = 'http://localhost:8099' + STI;
+  const API_URL_BACKEND: string =
+    'https://nav-familie-endringsmelding-api.fly.dev' + STI;
+
   const requestInfo = new Request(LOKAL_URL_BACKEND, {
     headers: {
       'Content-Type': 'application/json',

--- a/app/server/sendEndringsmelding.server.ts
+++ b/app/server/sendEndringsmelding.server.ts
@@ -6,16 +6,16 @@ import { EMiljø } from '~/typer/miljø';
 
 import { postMedToken } from './authorization';
 
+const STI: string = '/api/send-inn';
+const LOKAL_URL_BACKEND: string = 'http://localhost:8099' + STI;
+const API_URL_BACKEND: string =
+  'https://nav-familie-endringsmelding-api.fly.dev' + STI;
+
 export async function sendEndringsmelding(
   endringsmelding: IEndringsmelding,
   ytelseSti: string,
   session: Session,
 ): Promise<Response> {
-  const STI: string = '/api/send-inn/' + ytelseSti;
-  const LOKAL_URL_BACKEND: string = 'http://localhost:8099' + STI;
-  const API_URL_BACKEND: string =
-    'https://nav-familie-endringsmelding-api.fly.dev' + STI;
-
   const requestInfo = new Request(LOKAL_URL_BACKEND, {
     headers: {
       'Content-Type': 'application/json',
@@ -28,7 +28,7 @@ export async function sendEndringsmelding(
     case EMiljø.LOKAL:
       return await postMedToken(
         session,
-        LOKAL_URL_BACKEND,
+        LOKAL_URL_BACKEND + ytelseSti,
         requestInfo,
         endringsmelding,
       );
@@ -38,7 +38,7 @@ export async function sendEndringsmelding(
     default:
       return await postMedToken(
         session,
-        API_URL_BACKEND,
+        API_URL_BACKEND + ytelseSti,
         requestInfo,
         endringsmelding,
       );

--- a/app/utils/hentPath.ts
+++ b/app/utils/hentPath.ts
@@ -25,3 +25,12 @@ export const hentPathForSteg = (ytelse: EYtelse, steg: ESteg) => {
       return urlForYtelse + '/kvittering';
   }
 };
+
+export const hentAPIPathForYtelse = (ytelse: EYtelse) => {
+  switch (ytelse) {
+    case EYtelse.BARNETRYGD:
+      return '/ba';
+    case EYtelse.KONTANTSTØTTE:
+      return '/ks';
+  }
+};


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

All data sendes til BAMottak gjennom `/send-inn/ba`. KS skal ha sitt eget mottak. Dette er allerede lagt til i api-et, og må bare legges opp til i frontend
[Lenke til trello kort](https://trello.com/c/FwBBbrbe/161-sende-endringsmelding-til-ks-endepunkt)

### Hvordan er det løst? 🧠
Sender inn ytelse som prop, slik at stien for `/api/send-inn/` varierer utifra ytelse