### PR TITLE
Definer minimumshøyde for side

### DIFF
--- a/app/komponenter/hovedInnhold/hovedInnhold.module.css
+++ b/app/komponenter/hovedInnhold/hovedInnhold.module.css
@@ -1,6 +1,7 @@
 .innholdKonteiner {
   padding: 1rem;
   max-width: 37.5rem;
+  min-height: 100vh;
   margin: 0 auto;
   padding-bottom: 5rem;
   display: flex;

--- a/app/komponenter/hovedInnhold/hovedInnhold.module.css
+++ b/app/komponenter/hovedInnhold/hovedInnhold.module.css
@@ -1,7 +1,6 @@
 .innholdKonteiner {
   padding: 1rem;
   max-width: 37.5rem;
-  min-height: 100vh;
   margin: 0 auto;
   padding-bottom: 5rem;
   display: flex;

--- a/app/root.module.css
+++ b/app/root.module.css
@@ -1,0 +1,9 @@
+.body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+main {
+  flex: 1;
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -21,6 +21,7 @@ import parse from 'html-react-parser';
 import { loggInn } from '~/server/authorization';
 import { API_TOKEN_NAME, commitSession, getSession } from '~/sessions';
 
+import css from './root.module.css';
 import { hentDekoratorHtml } from './server/dekorator.server';
 import Feilside from './sider/Feilside';
 import { ELocaleType } from './typer/felles';
@@ -100,7 +101,7 @@ export function Dokument({ children }: DokumentProps) {
         {parse(dekoratørFragmenter.DECORATOR_STYLES, { trim: true })}
         <Links />
       </head>
-      <body>{children}</body>
+      <body className={`${css.body}`}>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

Fikse så ikke footer kommer midt på siden ved manglende sideinnhold
[Lenke til trello kort](https://trello.com/c/ioc0jnBd/167-fikset-høyde-på-side)

### Hvordan er det løst? 🧠
Lagt inn `min-height: 100vh` I InnholdsKonteiner, ettersom denne omfavner alt mellom banner og footer.