### PR TITLE
Oppdater sending av endringsmelding

### DIFF
--- a/app/hooks/contextHooks.ts
+++ b/app/hooks/contextHooks.ts
@@ -23,6 +23,11 @@ export function useBekreftetSamtykke() {
   return erSamtykkeBekreftet;
 }
 
+export function useEndringsmelding() {
+  const { endringsmelding } = useOutletContext<IAppContext>();
+  return endringsmelding;
+}
+
 export function useEndringsmeldingMottattDato() {
   const { endringsmeldingMottattDato } = useOutletContext<IAppContext>();
   return endringsmeldingMottattDato;

--- a/app/routes/ba.dokumentasjon.tsx
+++ b/app/routes/ba.dokumentasjon.tsx
@@ -1,4 +1,11 @@
+import { ActionArgs } from '@remix-run/node';
+
+import sendEndringAction from '~/server/sendEndringAction.server';
 import DokumentasjonSide from '~/sider/Dokumentasjon';
+
+export async function action({ request }: ActionArgs) {
+  return sendEndringAction(request);
+}
 
 export default function BADokumentasjon() {
   return <DokumentasjonSide />;

--- a/app/routes/ba.endringsmelding.tsx
+++ b/app/routes/ba.endringsmelding.tsx
@@ -1,11 +1,4 @@
-import { ActionArgs } from '@remix-run/node';
-
-import sendEndringAction from '~/server/sendEndringAction.server';
 import SendEndringSide from '~/sider/SendEndring';
-
-export async function action({ request }: ActionArgs) {
-  return sendEndringAction(request);
-}
 
 export default function BAEndringsmelding() {
   return <SendEndringSide />;

--- a/app/routes/ba.tsx
+++ b/app/routes/ba.tsx
@@ -2,6 +2,7 @@ import { LoaderArgs, LoaderFunction } from '@remix-run/node';
 import { Outlet, useLoaderData } from '@remix-run/react';
 import { useState } from 'react';
 
+import { IEndringsmelding } from '~/typer/endringsmelding';
 import { ELocaleType } from '~/typer/felles';
 import { EYtelse } from '~/typer/ytelse';
 import { ytelseLoader } from '~/utils/ytelseLoader';
@@ -14,6 +15,10 @@ export default function BarnetrygdIndex() {
   const { tekstData, søkerData } = useLoaderData<typeof loader>();
   const [språk, settSpråk] = useState<ELocaleType>(ELocaleType.NB);
   const [erSamtykkeBekreftet, settErSamtykkeBekreftet] = useState(false);
+  const [endringsmelding, settEndringsmelding] = useState<IEndringsmelding>({
+    tekst: '',
+    dokumenter: [],
+  });
   const [endringsmeldingMottattDato, settEndringsmeldingMottattDato] =
     useState('');
 
@@ -24,6 +29,7 @@ export default function BarnetrygdIndex() {
         språk: [språk, settSpråk],
         søker: søkerData,
         erSamtykkeBekreftet: [erSamtykkeBekreftet, settErSamtykkeBekreftet],
+        endringsmelding: [endringsmelding, settEndringsmelding],
         endringsmeldingMottattDato: [
           endringsmeldingMottattDato,
           settEndringsmeldingMottattDato,

--- a/app/routes/ks.dokumentasjon.tsx
+++ b/app/routes/ks.dokumentasjon.tsx
@@ -1,4 +1,11 @@
+import { ActionArgs } from '@remix-run/node';
+
+import sendEndringAction from '~/server/sendEndringAction.server';
 import DokumentasjonSide from '~/sider/Dokumentasjon';
+
+export async function action({ request }: ActionArgs) {
+  return sendEndringAction(request);
+}
 
 export default function KSDokumentasjon() {
   return <DokumentasjonSide />;

--- a/app/routes/ks.endringsmelding.tsx
+++ b/app/routes/ks.endringsmelding.tsx
@@ -1,11 +1,4 @@
-import { ActionArgs } from '@remix-run/node';
-
-import sendEndringAction from '~/server/sendEndringAction.server';
 import SendEndringSide from '~/sider/SendEndring';
-
-export async function action({ request }: ActionArgs) {
-  return sendEndringAction(request);
-}
 
 export default function KSEndringsmelding() {
   return <SendEndringSide />;

--- a/app/routes/ks.tsx
+++ b/app/routes/ks.tsx
@@ -2,6 +2,7 @@ import { LoaderArgs, LoaderFunction } from '@remix-run/node';
 import { Outlet, useLoaderData } from '@remix-run/react';
 import { useState } from 'react';
 
+import { IEndringsmelding } from '~/typer/endringsmelding';
 import { ELocaleType } from '~/typer/felles';
 import { EYtelse } from '~/typer/ytelse';
 import { ytelseLoader } from '~/utils/ytelseLoader';
@@ -17,6 +18,7 @@ export default function KontantStøtteIndex() {
   const { tekstData, søkerData } = useLoaderData<typeof loader>();
   const [språk, settSpråk] = useState<ELocaleType>(ELocaleType.NB);
   const [erSamtykkeBekreftet, settErSamtykkeBekreftet] = useState(false);
+  const endringsmelding: IEndringsmelding = { tekst: '', dokumenter: [] };
   const [endringsmeldingMottattDato, settEndringsmeldingMottattDato] =
     useState('');
 
@@ -27,6 +29,7 @@ export default function KontantStøtteIndex() {
         språk: [språk, settSpråk],
         søker: søkerData,
         erSamtykkeBekreftet: [erSamtykkeBekreftet, settErSamtykkeBekreftet],
+        endringsmelding: endringsmelding,
         endringsmeldingMottattDato: [
           endringsmeldingMottattDato,
           settEndringsmeldingMottattDato,

--- a/app/routes/ks.tsx
+++ b/app/routes/ks.tsx
@@ -18,7 +18,10 @@ export default function KontantStøtteIndex() {
   const { tekstData, søkerData } = useLoaderData<typeof loader>();
   const [språk, settSpråk] = useState<ELocaleType>(ELocaleType.NB);
   const [erSamtykkeBekreftet, settErSamtykkeBekreftet] = useState(false);
-  const endringsmelding: IEndringsmelding = { tekst: '', dokumenter: [] };
+  const [endringsmelding, settEndringsmelding] = useState<IEndringsmelding>({
+    tekst: '',
+    dokumenter: [],
+  });
   const [endringsmeldingMottattDato, settEndringsmeldingMottattDato] =
     useState('');
 
@@ -29,7 +32,7 @@ export default function KontantStøtteIndex() {
         språk: [språk, settSpråk],
         søker: søkerData,
         erSamtykkeBekreftet: [erSamtykkeBekreftet, settErSamtykkeBekreftet],
-        endringsmelding: endringsmelding,
+        endringsmelding: [endringsmelding, settEndringsmelding],
         endringsmeldingMottattDato: [
           endringsmeldingMottattDato,
           settEndringsmeldingMottattDato,

--- a/app/sider/Dokumentasjon.tsx
+++ b/app/sider/Dokumentasjon.tsx
@@ -11,13 +11,11 @@ import {
 import HovedInnhold from '~/komponenter/hovedInnhold/HovedInnhold';
 import StegIndikator from '~/komponenter/stegindikator/StegIndikator';
 import TekstBlokk from '~/komponenter/tekstblokk/TekstBlokk';
-import { action as actionBA } from '~/routes/ba.dokumentasjon';
-import { action as actionKS } from '~/routes/ks.dokumentasjon';
 import { ESanityMappe, ESteg } from '~/typer/felles';
 import { EFritekstFeil, fritekstFeilTilApiKeys } from '~/typer/fritekstfeil';
 import { EStatusKode, IPostResponse } from '~/typer/response';
 import { ETypografiTyper } from '~/typer/typografi';
-import { EYtelse } from '~/typer/ytelse';
+import { hentAction } from '~/utils/hentAction';
 import { hentPathForSteg } from '~/utils/hentPath';
 
 import css from './dokumentasjon.module.css';
@@ -33,7 +31,7 @@ export default function DokumentasjonSide() {
   const navigate = useNavigate();
   const submit = useSubmit();
 
-  const action = ytelse === EYtelse.BARNETRYGD ? actionBA : actionKS;
+  const action = hentAction(ytelse);
   const actionData: IPostResponse | undefined = useActionData<typeof action>();
 
   const [feilKode, settFeilKode] = useState<EFritekstFeil | null>(null);

--- a/app/sider/Dokumentasjon.tsx
+++ b/app/sider/Dokumentasjon.tsx
@@ -1,29 +1,70 @@
-import { Button } from '@navikt/ds-react';
-import { useNavigate } from '@remix-run/react';
+import { Alert, Button } from '@navikt/ds-react';
+import { useActionData, useNavigate, useSubmit } from '@remix-run/react';
+import { useEffect, useState } from 'react';
 
-import { useTekster, useYtelse } from '~/hooks/contextHooks';
+import {
+  useEndringsmelding,
+  useEndringsmeldingMottattDato,
+  useTekster,
+  useYtelse,
+} from '~/hooks/contextHooks';
 import HovedInnhold from '~/komponenter/hovedInnhold/HovedInnhold';
 import StegIndikator from '~/komponenter/stegindikator/StegIndikator';
 import TekstBlokk from '~/komponenter/tekstblokk/TekstBlokk';
+import { action as actionBA } from '~/routes/ba.dokumentasjon';
+import { action as actionKS } from '~/routes/ks.dokumentasjon';
 import { ESanityMappe, ESteg } from '~/typer/felles';
+import { EFritekstFeil, fritekstFeilTilApiKeys } from '~/typer/fritekstfeil';
+import { EStatusKode, IPostResponse } from '~/typer/response';
+import { EYtelse } from '~/typer/ytelse';
 import { hentPathForSteg } from '~/utils/hentPath';
 
 import css from './dokumentasjon.module.css';
 
 export default function DokumentasjonSide() {
   const ytelse = useYtelse();
-  const navigate = useNavigate();
-
   const teksterFelles = useTekster(ESanityMappe.FELLES);
+  const tekster = useTekster(ESanityMappe.SEND_ENDRINGER);
+  const [endringsmelding] = useEndringsmelding();
+  const [, settEndringsmeldingMottattDato] = useEndringsmeldingMottattDato();
 
-  function håndterSendDokumentasjon() {
-    //TODO: legge til en submit-funksjon, i tillegg til en action. Navigere videre til kvitteringsside med dataen.
+  const navigate = useNavigate();
+  const submit = useSubmit();
+
+  const action = ytelse === EYtelse.BARNETRYGD ? actionBA : actionKS;
+  const actionData: IPostResponse | undefined = useActionData<typeof action>();
+
+  const [feilKode, settFeilKode] = useState<EFritekstFeil | null>(null);
+
+  useEffect(() => {
+    if (!actionData) return;
+
+    if (actionData.status === EStatusKode.OK && actionData.data) {
+      settEndringsmeldingMottattDato(actionData.data.mottattDato);
+      navigate(hentPathForSteg(ytelse, ESteg.KVITTERING));
+    } else {
+      settFeilKode(actionData.feilKode || null);
+    }
+  }, [actionData, navigate, settEndringsmeldingMottattDato, ytelse]);
+
+  function håndterSendEndringsmelding() {
+    const formData = new FormData();
+    formData.append('endringsmelding', endringsmelding.tekst);
+    submit(formData, {
+      method: 'post',
+      action: hentPathForSteg(ytelse, ESteg.DOKUMENTASJON),
+    });
   }
 
   return (
     <HovedInnhold måHaBekreftetSamtykke>
       <StegIndikator nåværendeSteg={2} />
       <h1>Dokumentasjonsopplastning her</h1>
+      {feilKode && (
+        <Alert variant="error" className={`${css.toppMargin}`}>
+          <TekstBlokk tekstblokk={tekster[fritekstFeilTilApiKeys[feilKode]]} />
+        </Alert>
+      )}
       <div className={`${css.navigeringsKnappKonteiner}`}>
         <Button
           type="button"
@@ -34,7 +75,12 @@ export default function DokumentasjonSide() {
         >
           <TekstBlokk tekstblokk={teksterFelles.knappTilbake} />
         </Button>
-        <Button variant={'primary'} onClick={håndterSendDokumentasjon}>
+
+        <Button
+          type="submit"
+          variant={'primary'}
+          onClick={håndterSendEndringsmelding}
+        >
           <TekstBlokk tekstblokk={teksterFelles.knappSendEndringer} />
         </Button>
       </div>

--- a/app/sider/SendEndring.tsx
+++ b/app/sider/SendEndring.tsx
@@ -105,7 +105,7 @@ export default function SendEndringSide() {
             <Button
               type="button"
               variant={valideringsfeil === null ? 'primary' : 'secondary'}
-              data-testid="knappVidereSteg2"
+              data-testid="knappVidereSteg1"
               onClick={håndterTrykkNeste}
             >
               <TekstBlokk tekstblokk={teksterFelles.knappNeste} />

--- a/app/sider/SendEndring.tsx
+++ b/app/sider/SendEndring.tsx
@@ -1,15 +1,9 @@
-import { Alert, Button, Textarea } from '@navikt/ds-react';
-import {
-  Form,
-  useActionData,
-  useNavigate,
-  useNavigation,
-  useSubmit,
-} from '@remix-run/react';
-import React, { useEffect, useState } from 'react';
+import { Button, Textarea } from '@navikt/ds-react';
+import { useNavigate, useNavigation } from '@remix-run/react';
+import React, { useState } from 'react';
 
 import {
-  useEndringsmeldingMottattDato,
+  useEndringsmelding,
   useSpråk,
   useTekster,
   useYtelse,
@@ -19,13 +13,9 @@ import Spinner from '~/komponenter/spinner/Spinner';
 import StegIndikator from '~/komponenter/stegindikator/StegIndikator';
 import TekstBlokk from '~/komponenter/tekstblokk/TekstBlokk';
 import VeilederPanel from '~/komponenter/veilederpanel/VeilederPanel';
-import { action as actionBA } from '~/routes/ba.endringsmelding';
-import { action as actionKS } from '~/routes/ks.endringsmelding';
 import { ESanityMappe, ESteg } from '~/typer/felles';
 import { EFritekstFeil, fritekstFeilTilApiKeys } from '~/typer/fritekstfeil';
-import { EStatusKode, IPostResponse } from '~/typer/response';
 import { ETypografiTyper } from '~/typer/typografi';
-import { EYtelse } from '~/typer/ytelse';
 import {
   i18nInnhold,
   MAKS_INPUT_LENGDE,
@@ -37,33 +27,18 @@ import css from './send-endringsmelding.module.css';
 
 export default function SendEndringSide() {
   const ytelse = useYtelse();
-  const action = ytelse === EYtelse.BARNETRYGD ? actionBA : actionKS;
-  const actionData: IPostResponse | undefined = useActionData<typeof action>();
-  const submit = useSubmit();
-
   const tekster = useTekster(ESanityMappe.SEND_ENDRINGER);
   const teksterFelles = useTekster(ESanityMappe.FELLES);
   const navigate = useNavigate();
   const navigation = useNavigation();
   const [språk] = useSpråk();
-  const [, settEndringsmeldingMottattDato] = useEndringsmeldingMottattDato();
-
-  const [feilKode, settFeilKode] = useState<EFritekstFeil | null>(null);
+  const [, settEndringsmelding] = useEndringsmelding();
   const [valideringsfeil, settValideringsfeil] = useState<EFritekstFeil | null>(
     EFritekstFeil.MANGLER_TEKST,
   );
   const [erKnappTrykketPå, settKnappTrykketPå] = useState<boolean>(false);
 
-  useEffect(() => {
-    if (!actionData) return;
-
-    if (actionData.status === EStatusKode.OK && actionData.data) {
-      settEndringsmeldingMottattDato(actionData.data.mottattDato);
-      navigate(hentPathForSteg(ytelse, ESteg.KVITTERING));
-    } else {
-      settFeilKode(actionData.feilKode || null);
-    }
-  }, [actionData, navigate, settEndringsmeldingMottattDato, ytelse]);
+  const [endringsmeldingInput, settEndringsmeldingInput] = useState<string>('');
 
   function genererFeilmelding() {
     return (
@@ -77,13 +52,10 @@ export default function SendEndringSide() {
     );
   }
 
-  function håndterSendEndringsmelding(
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-  ) {
-    event.preventDefault();
+  function håndterTrykkNeste() {
     if (valideringsfeil === null) {
-      settFeilKode(null);
-      submit(event.currentTarget, { replace: true });
+      settEndringsmelding({ tekst: endringsmeldingInput, dokumenter: [] });
+      navigate(hentPathForSteg(ytelse, ESteg.DOKUMENTASJON));
     }
     settKnappTrykketPå(true);
   }
@@ -101,64 +73,44 @@ export default function SendEndringSide() {
             dataTestid="overskriftSteg1"
           />
           <VeilederPanel innhold={tekster.veilederInnhold} />
-          <Form method="post" className={`${css.fullBredde}`}>
-            <Textarea
-              data-testid="fritekstfelt"
-              name="endringsmelding"
-              label={
-                <TekstBlokk
-                  tekstblokk={tekster.fritekstfeltTittel}
-                  dataTestid="fritekstfeltTittel"
-                />
-              }
-              description={
-                <TekstBlokk tekstblokk={tekster.fritekstfeltBeskrivelse} />
-              }
-              autoComplete="on"
-              maxLength={MAKS_INPUT_LENGDE}
-              i18n={i18nInnhold(språk)}
-              error={genererFeilmelding()}
-              onInput={event => {
-                settValideringsfeil(validerTekst(event.currentTarget.value));
-              }}
-            />
-            {feilKode && (
-              <Alert variant="error" className={`${css.toppMargin}`}>
-                <TekstBlokk
-                  tekstblokk={tekster[fritekstFeilTilApiKeys[feilKode]]}
-                />
-              </Alert>
-            )}
-            <div className={`${css.navigeringsKnappKonteiner}`}>
-              <Button
-                type="button"
-                variant={'secondary'}
-                onClick={() => navigate(hentPathForSteg(ytelse, ESteg.FORSIDE))}
-              >
-                <TekstBlokk tekstblokk={teksterFelles.knappTilbake} />
-              </Button>
-              <Button
-                type="button"
-                variant={valideringsfeil === null ? 'primary' : 'secondary'}
-                data-testid="knappVidereSteg2"
-                onClick={() =>
-                  navigate(hentPathForSteg(ytelse, ESteg.DOKUMENTASJON))
-                }
-              >
-                <TekstBlokk tekstblokk={teksterFelles.knappNeste} />
-              </Button>
-              <Button
-                type="submit"
-                variant={valideringsfeil === null ? 'primary' : 'secondary'}
-                data-testid="knappVidereSteg1"
-                onClick={event => {
-                  håndterSendEndringsmelding(event);
-                }}
-              >
-                <TekstBlokk tekstblokk={teksterFelles.knappSendEndringer} />
-              </Button>
-            </div>
-          </Form>
+          <Textarea
+            data-testid="fritekstfelt"
+            name="endringsmelding"
+            label={
+              <TekstBlokk
+                tekstblokk={tekster.fritekstfeltTittel}
+                dataTestid="fritekstfeltTittel"
+              />
+            }
+            description={
+              <TekstBlokk tekstblokk={tekster.fritekstfeltBeskrivelse} />
+            }
+            autoComplete="on"
+            maxLength={MAKS_INPUT_LENGDE}
+            i18n={i18nInnhold(språk)}
+            error={genererFeilmelding()}
+            onInput={event => {
+              settValideringsfeil(validerTekst(event.currentTarget.value));
+              settEndringsmeldingInput(event.currentTarget.value);
+            }}
+          />
+          <div className={`${css.navigeringsKnappKonteiner}`}>
+            <Button
+              type="button"
+              variant={'secondary'}
+              onClick={() => navigate(hentPathForSteg(ytelse, ESteg.FORSIDE))}
+            >
+              <TekstBlokk tekstblokk={teksterFelles.knappTilbake} />
+            </Button>
+            <Button
+              type="button"
+              variant={valideringsfeil === null ? 'primary' : 'secondary'}
+              data-testid="knappVidereSteg2"
+              onClick={håndterTrykkNeste}
+            >
+              <TekstBlokk tekstblokk={teksterFelles.knappNeste} />
+            </Button>
+          </div>
         </>
       )}
     </HovedInnhold>

--- a/app/sider/SendEndring.tsx
+++ b/app/sider/SendEndring.tsx
@@ -32,13 +32,15 @@ export default function SendEndringSide() {
   const navigate = useNavigate();
   const navigation = useNavigation();
   const [språk] = useSpråk();
-  const [, settEndringsmelding] = useEndringsmelding();
+  const [endringsmelding, settEndringsmelding] = useEndringsmelding();
   const [valideringsfeil, settValideringsfeil] = useState<EFritekstFeil | null>(
     EFritekstFeil.MANGLER_TEKST,
   );
   const [erKnappTrykketPå, settKnappTrykketPå] = useState<boolean>(false);
 
-  const [endringsmeldingInput, settEndringsmeldingInput] = useState<string>('');
+  const [endringsmeldingInput, settEndringsmeldingInput] = useState<string>(
+    endringsmelding.tekst,
+  );
 
   function genererFeilmelding() {
     return (
@@ -54,7 +56,10 @@ export default function SendEndringSide() {
 
   function håndterTrykkNeste() {
     if (valideringsfeil === null) {
-      settEndringsmelding({ tekst: endringsmeldingInput, dokumenter: [] });
+      settEndringsmelding(endringsmelding => ({
+        ...endringsmelding,
+        tekst: endringsmeldingInput,
+      }));
       navigate(hentPathForSteg(ytelse, ESteg.DOKUMENTASJON));
     }
     settKnappTrykketPå(true);
@@ -89,6 +94,7 @@ export default function SendEndringSide() {
             maxLength={MAKS_INPUT_LENGDE}
             i18n={i18nInnhold(språk)}
             error={genererFeilmelding()}
+            defaultValue={endringsmelding.tekst}
             onInput={event => {
               settValideringsfeil(validerTekst(event.currentTarget.value));
               settEndringsmeldingInput(event.currentTarget.value);

--- a/app/sider/dokumentasjon.module.css
+++ b/app/sider/dokumentasjon.module.css
@@ -6,3 +6,7 @@
   justify-content: center;
   gap: 1rem;
 }
+
+.toppMargin {
+  margin-top: 5rem;
+}

--- a/app/sider/send-endringsmelding.module.css
+++ b/app/sider/send-endringsmelding.module.css
@@ -6,11 +6,3 @@
   justify-content: center;
   gap: 1rem;
 }
-
-.fullBredde {
-  width: 100%;
-}
-
-.toppMargin {
-  margin-top: 5rem;
-}

--- a/app/typer/context.ts
+++ b/app/typer/context.ts
@@ -1,5 +1,6 @@
 import { Dispatch, SetStateAction } from 'react';
 
+import { IEndringsmelding } from './endringsmelding';
 import { ELocaleType } from './felles';
 import { ITekstinnhold } from './sanity/sanity';
 import { ISøker } from './søker';
@@ -9,7 +10,11 @@ export interface IAppContext {
   sanityTekster: ITekstinnhold;
   språk: [ELocaleType, Dispatch<SetStateAction<ELocaleType>>];
   søker: ISøker;
-  endringsmeldingMottattDato: [string, Dispatch<SetStateAction<string>>];
   erSamtykkeBekreftet: [boolean, Dispatch<SetStateAction<boolean>>];
+  endringsmelding: [
+    IEndringsmelding,
+    Dispatch<SetStateAction<IEndringsmelding>>,
+  ];
+  endringsmeldingMottattDato: [string, Dispatch<SetStateAction<string>>];
   ytelse: EYtelse;
 }

--- a/app/utils/hentAction.ts
+++ b/app/utils/hentAction.ts
@@ -1,0 +1,12 @@
+import { action as actionBA } from '~/routes/ba.dokumentasjon';
+import { action as actionKS } from '~/routes/ks.dokumentasjon';
+import { EYtelse } from '~/typer/ytelse';
+
+export const hentAction = (ytelse: EYtelse) => {
+  switch (ytelse) {
+    case EYtelse.BARNETRYGD:
+      return actionBA;
+    case EYtelse.KONTANTSTØTTE:
+      return actionKS;
+  }
+};


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

Endrinsmeldingen skal ikke sendes inn på SendEndringer, ettersom brukeren skal ha mulighet til å legge ved dokumenter til endringsmeldingen. Den skal derfor sendes inn ved dokumentasjonssiden.
[Lenke til trello kort](https://trello.com/c/rfNTPxhZ/170-sende-endringsmelding-fra-dokumentasjonssiden)

### Hvordan er det løst? 🧠
Endringsmeldingen lagres i en kontekst, og sendes videre til dokumentasjonssiden. Logikken for å sende inn data til action-funksjon, er flyttet fra `SendEndring` til `Dokumentasjon`, som submitter det lagrede objektet bestående av endringsmeldingen og id-er på ev. vedlagte dokumenter. Registrering av mottatt data er også overført til `Dokumentasjon`, som registrerer datoen til bruk i kvitteringssiden. 

Se commit;
ebaf4d8668e1737b759ca63fb11d2327ef81a0c5 for lagring av endringsmelding som objekt i context
d5ae84b9d3a219d90b3ef1cf8b73e7de5f59a45c for flytting av action fra endringsmelding til dokumentasjon
ebaf4d8668e1737b759ca63fb11d2327ef81a0c5 for flytting av logikk fra `Endringsmelding` til `Dokumentasjon`


**Videre utdypt**
Vi har ikke koblet dette opp mot endepunktet for innhenting av id-er til dokumenter. Derfor er objektet bestående av en tom array, og det eneste som sendes inn til action er selve endringsmeldingen. 