### PR TITLE
Lastet opp veiledning på dokumentasjonsiden

### DIFF
--- a/app/sider/Dokumentasjon.tsx
+++ b/app/sider/Dokumentasjon.tsx
@@ -29,6 +29,7 @@ export default function DokumentasjonSide() {
         tekstblokk={tekster.dokumentasjonOverskrift}
         typografi={ETypografiTyper.STEG_HEADING_SMALL_H1}
       />
+      <TekstBlokk tekstblokk={tekster.veiledning} />
       <div className={`${css.navigeringsKnappKonteiner}`}>
         <Button
           type="button"

--- a/app/typer/sanity/sanityDokumentasjon.ts
+++ b/app/typer/sanity/sanityDokumentasjon.ts
@@ -3,6 +3,7 @@ import { ISanityDokument } from './sanity';
 export enum EApiKeysDokumentasjon {
   DOKUMENTASJON = 'Dokumentasjon',
   OVERSKRIFT = 'dokumentasjonOverskrift',
+  veiledning = 'veiledning',
 }
 
 export type DokumentasjonTekstInnhold = Record<


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
la til et tekstavsnitt som skal vises på dokumentasjonsiden som skal forklare hvordan man laster opp dokumentasjon
[Lenke til trello kort](https://trello.com/c/PS2qYSXr/156-legge-til-tekst-på-dokumentasjonssiden)

### Hvordan er det løst? 🧠
Teksten er lagt til i sanity. Den er også lagt til i sanity mappen i koden for å hente teksten fra sanity. teksten er lagt til i tekstblokk på dokumentasjonSiden 
<img width="671" alt="Screenshot 2023-07-25 at 10 26 07" src="https://github.com/bekk/nav-familie-endringsmelding/assets/31205453/61d075dd-ad1e-48ea-83a5-3b6d6d391816">

