### PR TITLE
Fjern store mellomrom i dokumentasjon-veileder

### DIFF
--- a/app/sider/Dokumentasjon.tsx
+++ b/app/sider/Dokumentasjon.tsx
@@ -31,7 +31,12 @@ export default function DokumentasjonSide() {
         tekstblokk={tekster.dokumentasjonOverskrift}
         typografi={ETypografiTyper.STEG_HEADING_SMALL_H1}
       />
-      <TekstBlokk tekstblokk={tekster.veiledning} />
+      <div>
+        <TekstBlokk
+          tekstblokk={tekster.veiledning}
+          typografi={ETypografiTyper.BODY_SHORT}
+        />
+      </div>
       <FilopplastningFelt />
       <div className={`${css.navigeringsKnappKonteiner}`}>
         <Button


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
Stylingen på dokumentasjonssiden hadde noen feil, som gjorde at mellomrommene i veiledningsteksten ble store.
<img width="737" alt="image" src="https://github.com/bekk/nav-familie-endringsmelding/assets/69514415/6c0bbd9a-1a57-4e95-881f-0f28dfdcc758">

### Hvordan er det løst? 🧠
Har lagt en div rundt tekstblokken, samt lagt til rett typografi.
<img width="737" alt="image" src="https://github.com/bekk/nav-familie-endringsmelding/assets/69514415/09d2541c-1958-422b-b3e3-12b74c8cec04">
