### PR TITLE
Fiks generell styling

### DIFF
--- a/app/komponenter/tekstblokk/TekstBlokk.tsx
+++ b/app/komponenter/tekstblokk/TekstBlokk.tsx
@@ -31,7 +31,7 @@ const TekstBlokk: React.FC<Props> = ({
           normal: ({ children }) => (
             <TypografiWrapper
               typografi={typografi}
-              style={{ margin: '0' }}
+              style={{ margin: '0', minHeight: '1rem' }}
               dataTestid={dataTestid}
             >
               {children}

--- a/app/komponenter/veilederpanel/veilederpanel.module.css
+++ b/app/komponenter/veilederpanel/veilederpanel.module.css
@@ -1,11 +1,14 @@
 .veilederPanel {
   width: 100%;
   padding: 0;
-  text-align: left;
 
   @media (max-width: 768px) {
     width: 80%;
   }
+}
+
+.veilederPanel ul {
+  padding-left: 1.5rem;
 }
 
 .bunnMargin {
@@ -18,5 +21,6 @@
 }
 
 .veilederPanelPoster ul {
-  margin: 0 auto 2rem auto;
+  margin: 0.5rem auto 2rem auto;
+  padding-left: 1.5rem;
 }

--- a/app/sider/Forside.tsx
+++ b/app/sider/Forside.tsx
@@ -56,7 +56,9 @@ const Forside: React.FC = () => {
               typografi={ETypografiTyper.HEADING_H1}
             />
           </div>
-          <Språkvelger />
+          <div className={`${css.overrideMarginer}`}>
+            <Språkvelger />
+          </div>
 
           <VeilederPanel
             innhold={tekster.veilederhilsenInnhold}

--- a/app/sider/dokumentasjon.module.css
+++ b/app/sider/dokumentasjon.module.css
@@ -7,6 +7,10 @@
   gap: 1rem;
 }
 
+.navigeringsKnappKonteiner > Button {
+  min-width: 10rem;
+}
+
 .toppMargin {
   margin-top: 5rem;
 }

--- a/app/sider/forside.module.css
+++ b/app/sider/forside.module.css
@@ -1,3 +1,9 @@
 .toppMargin {
   margin-top: 5rem;
+  gap: 0;
+}
+
+.overrideMarginer {
+  margin-top: -2.5rem;
+  margin-bottom: 5rem;
 }

--- a/app/sider/forside.module.css
+++ b/app/sider/forside.module.css
@@ -4,6 +4,6 @@
 }
 
 .overrideMarginer {
-  margin-top: -2.5rem;
-  margin-bottom: 5rem;
+  margin-top: -3rem;
+  margin-bottom: 2.5rem;
 }

--- a/app/sider/send-endringsmelding.module.css
+++ b/app/sider/send-endringsmelding.module.css
@@ -6,3 +6,7 @@
   justify-content: center;
   gap: 1rem;
 }
+
+.navigeringsKnappKonteiner > Button {
+  min-width: 10rem;
+}


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

Generell fiksing av elementer så de er mer i tråd med skissene, eller bare generelt ser litt ryddigere ut 🧽🫧🧹

### Hvordan er det løst? 🧠
Ulike commits for ulike fix:

8e50b9f3434f614b278ee8946c6fe9be3f146806 / 04c5c6552b72ac40ae603d7a93d56afc0755150b : Justere gaps på forsiden så ikke alt er helt jevnt, men heller tråd med V2-skissene - ser mer naturlig ut.
<img width="350" alt="image" src="https://github.com/bekk/nav-familie-endringsmelding/assets/69514415/f8f0ce7d-2b0a-4643-8d8c-f2b5b4405483">

<img width="350" alt="image" src="https://github.com/bekk/nav-familie-endringsmelding/assets/69514415/22da56a5-9dcc-46e8-86a4-1f97e060a57a">
<br/><br/>
4a2e40ca5ee8e503f53f738a036de3ce556363bb : Fikser listene i veilederpanel, så de ike er stilt for langt mot høyre.
<img width="350" alt="image" src="https://github.com/bekk/nav-familie-endringsmelding/assets/69514415/34e655d5-cd12-4a68-935e-e76ccb79a81f">

<img width="350" alt="image" src="https://github.com/bekk/nav-familie-endringsmelding/assets/69514415/6bb549c9-e586-4811-884a-ccf880103604">
<br/><br/>
9bd34a3adef3d23b7ef5647fef4bca40460f852e : Minimumsbredde på knapper
<img width="300" alt="image" src="https://github.com/bekk/nav-familie-endringsmelding/assets/69514415/d1d04d98-8d7e-44e7-b46c-161904ff29cb">

<img width="300" alt="image" src="https://github.com/bekk/nav-familie-endringsmelding/assets/69514415/37af9c30-c2d9-46c3-bb96-a2b700055941">
<br/><br/>
b1944b45c35bb6e79a5ad8942484ef4dafd7f72e : Fikset høyde på teksten hentet fra Sanity, slik at større tekstbolker ikke blir fullt så tettpakka
<img width="350" alt="image" src="https://github.com/bekk/nav-familie-endringsmelding/assets/69514415/7138a094-5316-4e2c-bfab-cf47a900f670">

<img width="350" alt="image" src="https://github.com/bekk/nav-familie-endringsmelding/assets/69514415/62db84dd-d28c-41d8-9ac6-cd703e9dd56d">
