### PR TITLE
Send dokument id-er med endringsmelding til backend

### DIFF
--- a/app/server/authorization.ts
+++ b/app/server/authorization.ts
@@ -1,7 +1,7 @@
 import { Session } from '@remix-run/node';
 
 import { API_TOKEN_NAME } from '~/sessions';
-import { IEndringsmelding } from '~/typer/endringsmelding';
+import { IEndringsmeldingFormData } from '~/typer/endringsmelding';
 import { EMiljø } from '~/typer/miljø';
 
 export const fetchMedToken = async (
@@ -20,7 +20,7 @@ export const postMedToken = async (
   session: Session,
   url: string,
   requestInfo?: Request,
-  payload?: IEndringsmelding,
+  payload?: IEndringsmeldingFormData,
 ): Promise<Response> => {
   const headersMedToken = await lagHeadersMedToken(session, requestInfo);
   return fetch(url, {

--- a/app/server/sendEndringAction.server.ts
+++ b/app/server/sendEndringAction.server.ts
@@ -1,6 +1,6 @@
 import { sendEndringsmelding } from '~/server/sendEndringsmelding.server';
 import { getSession } from '~/sessions';
-import { IEndringsmelding } from '~/typer/endringsmelding';
+import { IEndringsmeldingFormData } from '~/typer/endringsmelding';
 import { EFritekstFeil } from '~/typer/fritekstfeil';
 import { EStatusKode, IPostResponse } from '~/typer/response';
 import { EYtelse } from '~/typer/ytelse';
@@ -11,10 +11,11 @@ export default async function sendEndringAction(
   ytelse: EYtelse,
 ) {
   const formData = await request.formData();
-  const endringsmeldingTekst = formData.get('endringsmelding') as string;
-  const endringsmelding: IEndringsmelding = {
-    tekst: endringsmeldingTekst,
-    dokumenter: [],
+  const tekst = formData.get('tekst') as string;
+  const dokumenter = formData.get('dokumenter') as string;
+  const endringsmelding: IEndringsmeldingFormData = {
+    tekst: tekst,
+    dokumenter: dokumenter,
   };
   const ytelseSti = hentAPIPathForYtelse(ytelse);
   return await sendEndringsmelding(

--- a/app/server/sendEndringsmelding.server.ts
+++ b/app/server/sendEndringsmelding.server.ts
@@ -1,7 +1,7 @@
 import { json, Session } from '@remix-run/node';
 
 import postResponseMock from '~/mock/postResponseMock';
-import { IEndringsmelding } from '~/typer/endringsmelding';
+import { IEndringsmeldingFormData } from '~/typer/endringsmelding';
 import { EMiljø } from '~/typer/miljø';
 
 import { postMedToken } from './authorization';
@@ -12,7 +12,7 @@ const API_URL_BACKEND: string =
   'https://nav-familie-endringsmelding-api.fly.dev' + STI;
 
 export async function sendEndringsmelding(
-  endringsmelding: IEndringsmelding,
+  endringsmelding: IEndringsmeldingFormData,
   ytelseSti: string,
   session: Session,
 ): Promise<Response> {

--- a/app/sider/Dokumentasjon.tsx
+++ b/app/sider/Dokumentasjon.tsx
@@ -13,7 +13,9 @@ import HovedInnhold from '~/komponenter/hovedInnhold/HovedInnhold';
 import StegIndikator from '~/komponenter/stegindikator/StegIndikator';
 import TekstBlokk from '~/komponenter/tekstblokk/TekstBlokk';
 import { EAction } from '~/typer/action';
+import { IEndringsmelding } from '~/typer/endringsmelding';
 import { ESanityMappe, ESteg } from '~/typer/felles';
+import { IFil, IPostFilResponse } from '~/typer/filopplastning';
 import { EFritekstFeil, fritekstFeilTilApiKeys } from '~/typer/fritekstfeil';
 import { EStatusKode, IPostResponse } from '~/typer/response';
 import { ETypografiTyper } from '~/typer/typografi';
@@ -27,27 +29,53 @@ export default function DokumentasjonSide() {
   const teksterDokumentasjon = useTekster(ESanityMappe.DOKUMENTASJON);
   const teksterFelles = useTekster(ESanityMappe.FELLES);
   const teksterSendEndringer = useTekster(ESanityMappe.SEND_ENDRINGER);
-  const [endringsmelding] = useEndringsmelding();
+  const [endringsmelding, settEndringsmelding] = useEndringsmelding();
   const [, settEndringsmeldingMottattDato] = useEndringsmeldingMottattDato();
 
   const navigate = useNavigate();
   const submit = useSubmit();
 
   const action = hentAction(ytelse);
-  const actionData: IPostResponse | undefined = useActionData<typeof action>();
+  const actionData: IPostResponse | IPostFilResponse | undefined =
+    useActionData<typeof action>();
 
   const [feilKode, settFeilKode] = useState<EFritekstFeil | null>(null);
 
   useEffect(() => {
     if (!actionData) return;
 
-    if (actionData.status === EStatusKode.OK && actionData.data) {
+    if (
+      actionData.status === EStatusKode.OK &&
+      'data' in actionData &&
+      actionData.data
+    ) {
       settEndringsmeldingMottattDato(actionData.data.mottattDato);
       navigate(hentPathForSteg(ytelse, ESteg.KVITTERING));
-    } else {
+    } else if (
+      actionData.status === EStatusKode.OK &&
+      'response' in actionData &&
+      actionData.response
+    ) {
+      actionData as IPostFilResponse;
+      const fil: IFil = actionData.response;
+      const dokumenter = endringsmelding.dokumenter;
+      dokumenter.push(fil.dokumentId);
+      const nyEndringsmelding: IEndringsmelding = {
+        dokumenter: dokumenter,
+        tekst: endringsmelding.tekst,
+      };
+      settEndringsmelding(nyEndringsmelding);
+    } else if ('data' in actionData) {
       settFeilKode(actionData.feilKode || null);
     }
-  }, [actionData, navigate, settEndringsmeldingMottattDato, ytelse]);
+  }, [
+    actionData,
+    navigate,
+    settEndringsmeldingMottattDato,
+    ytelse,
+    settEndringsmelding,
+    endringsmelding,
+  ]);
 
   function håndterSendEndringsmelding() {
     const formData = new FormData();

--- a/app/sider/Dokumentasjon.tsx
+++ b/app/sider/Dokumentasjon.tsx
@@ -43,7 +43,6 @@ export default function DokumentasjonSide() {
 
   useEffect(() => {
     if (!actionData) return;
-    console.log('kjøh');
     if (
       actionData.status === EStatusKode.OK &&
       'data' in actionData &&

--- a/app/sider/Dokumentasjon.tsx
+++ b/app/sider/Dokumentasjon.tsx
@@ -43,7 +43,7 @@ export default function DokumentasjonSide() {
 
   useEffect(() => {
     if (!actionData) return;
-
+    console.log('kjøh');
     if (
       actionData.status === EStatusKode.OK &&
       'data' in actionData &&
@@ -74,13 +74,18 @@ export default function DokumentasjonSide() {
     settEndringsmeldingMottattDato,
     ytelse,
     settEndringsmelding,
-    endringsmelding,
+    endringsmelding.dokumenter,
+    endringsmelding.tekst,
   ]);
 
   function håndterSendEndringsmelding() {
+    let dokumenterStreng = '';
+    endringsmelding.dokumenter.forEach(dok => (dokumenterStreng += dok + ','));
     const formData = new FormData();
-    formData.append('endringsmelding', endringsmelding.tekst);
+    formData.append('tekst', endringsmelding.tekst);
+    formData.append('dokumenter', dokumenterStreng);
     formData.append('_action', EAction.SEND_ENDRINGER);
+
     submit(formData, {
       method: 'post',
       action: hentPathForSteg(ytelse, ESteg.DOKUMENTASJON),

--- a/app/typer/endringsmelding.ts
+++ b/app/typer/endringsmelding.ts
@@ -2,3 +2,8 @@ export interface IEndringsmelding {
   tekst: string;
   dokumenter: string[];
 }
+
+export interface IEndringsmeldingFormData {
+  tekst: string;
+  dokumenter: string;
+}


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
For at vi skal kunne lagre dokumenter sammen med endringsmeldingen må id-ene til dokumentene sendes med endringsmeldingen til backend. 

[Lenke til trello kort](https://trello.com/c/sX7iM2KD/160-sende-med-id-fra-dokument-med-endringsmeldingen)

### Hvordan er det løst? 🧠

Det er laget et nytt interface IEndringsmeldingFormData der dokumenter er en string som sendes med som payload. 

Den tomme arrayen som ble sendt med Endringsmelding før er byttet ut med en string av dokument id-ene og blir lagt til i endringsmeldingsobjektet. 

I useEffecten til actionData har response som vil si at en fil er lastet opp og det er kommet en id for det dokumentet. Det legges da til i endringsmelding contexten. Har actionData data betyr det at man har sendt inn hele endringsmeldingen og det navigeres til kvitteringssiden som før om alt går bra. 