### PR TITLE
Fjern margin top på knapper i Send endringsmelding-steget

### DIFF
--- a/app/sider/send-endringsmelding.module.css
+++ b/app/sider/send-endringsmelding.module.css
@@ -1,5 +1,4 @@
 .navigeringsKnappKonteiner {
-  margin-top: 5rem;
   min-width: 17rem;
   display: flex;
   flex-direction: row;

--- a/cypress/e2e/forside.cy.ts
+++ b/cypress/e2e/forside.cy.ts
@@ -12,7 +12,7 @@ describe('Forside tester', () => {
   });
   it('Fornavn hentet fra backend', () => {
     //TODO: Endre til det fornavnet vi vil hente, mocket
-    cy.get(`[data-testid='hilsenFornavn']`).contains('Hei, Fornavn!');
+    cy.get(`[data-testid='hilsenFornavn']`).contains('Hei, Askeladden!');
   });
   it('Kan ikke gå videre før samtykkepanel er bekreftet', () => {
     cy.get(`[data-testid='startKnapp']`).click();


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
Bitteliten fiks fordi det var veldig stort mellomrom mellom fritekstfelt og knappene. 

### Hvordan er det løst? 🧠
Fjernet margin-top på navigeringsknapper. 